### PR TITLE
Enhance payee visualization with colored Bokeh quadtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Utility for extracting the "Monthly Disbursement and Check Register Report"
 from El Camino Healthcare District agenda packet PDFs.  The script
 `check_register_parser.py` reads a packet PDF and emits a CSV file containing
 one row per check along with a couple of simple aggregates.  It can also
-produce an HTML treemap showing payees sized by total dollar amount.
+produce an HTML quadtree showing payees sized by total dollar amount.
 
 ## Usage
 

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -26,6 +26,7 @@ import argparse
 import csv
 import json
 import re
+import logging
 from dataclasses import dataclass, asdict
 from decimal import Decimal
 from pathlib import Path
@@ -215,6 +216,7 @@ class CheckRegisterParser:
         current_row: Optional[CheckEntry] = None
         current_block: str = ""
 
+        logging.getLogger("pdfminer").setLevel(logging.ERROR)
         with pdfplumber.open(self.pdf_path) as pdf:
             for page in pdf.pages:
                 lines = (page.extract_text() or "").splitlines()
@@ -357,8 +359,17 @@ class CheckRegisterParser:
             )
 
     @staticmethod
-    def write_payee_treemap_html(entries: List[CheckEntry], out_path: Path) -> None:
-        """Write an HTML treemap of payees sized by total dollar amount."""
+    def write_payee_quadtree_html(entries: List[CheckEntry], out_path: Path) -> None:
+        """Write an HTML quadtree of payees sized by total dollar amount.
+
+        Rectangles are colored using a linear ramp so larger dollar amounts
+        stand out.
+        """
+
+        from bokeh.plotting import figure, output_file, save
+        from bokeh.models import ColumnDataSource, HoverTool
+        from bokeh.transform import linear_cmap
+        from bokeh.palettes import Viridis256
 
         totals: Dict[str, Decimal] = {}
         for e in entries:
@@ -366,39 +377,95 @@ class CheckRegisterParser:
                 continue
             totals[e.payee] = totals.get(e.payee, Decimal("0.00")) + e.amount
 
-        data = {
-            "name": "Payees",
-            "children": [
-                {"name": name, "value": float(amount)}
-                for name, amount in sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
-            ],
-        }
+        items = [(name, float(amount)) for name, amount in totals.items() if float(amount) > 0]
 
-        out_path = Path(out_path)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        with out_path.open("w", encoding="utf-8") as f:
-            f.write(
-                "<!DOCTYPE html>\n<html><head><meta charset='utf-8'>"
-                "<title>Payees by Dollar Amount</title>"
-                "<style>body{font-family:sans-serif}</style>"
-                "</head><body><div id='chart'></div>"
-                "<script src='https://d3js.org/d3.v7.min.js'></script><script>"
-                "const data = "
+        def greedy_split_2(items):
+            left_group, right_group, sum_left, sum_right = [], [], 0.0, 0.0
+            for label, weight in sorted(items, key=lambda t: t[1], reverse=True):
+                if sum_left <= sum_right:
+                    left_group.append((label, weight))
+                    sum_left += weight
+                else:
+                    right_group.append((label, weight))
+                    sum_right += weight
+            return left_group, right_group, sum_left, sum_right
+
+        def greedy_split_4(items):
+            left_items, right_items, sum_left, sum_right = greedy_split_2(items)
+            top_left, bottom_left, sum_top_left, sum_bottom_left = (
+                greedy_split_2(left_items) if left_items else ([], [], 0, 0)
             )
-            json.dump(data, f)
-            f.write(
-                ";\nconst width=960,height=600;\n"
-                "const root=d3.treemap().size([width,height]).padding(1)"
-                "(d3.hierarchy(data).sum(d=>d.value));\n"
-                "const svg=d3.select('#chart').append('svg').attr('width',width).attr('height',height);\n"
-                "const g=svg.selectAll('g').data(root.leaves()).enter().append('g')"
-                ".attr('transform',d=>`translate(${d.x0},${d.y0})`);\n"
-                "g.append('rect').attr('width',d=>d.x1-d.x0).attr('height',d=>d.y1-d.y0)"
-                ".attr('fill','#1f77b4');\n"
-                "g.append('title').text(d=>`${d.data.name}: $${d.data.value.toLocaleString()}`);\n"
-                "g.append('text').attr('x',4).attr('y',14).text(d=>d.data.name);\n"
-                "</script></body></html>"
+            top_right, bottom_right, sum_top_right, sum_bottom_right = (
+                greedy_split_2(right_items) if right_items else ([], [], 0, 0)
             )
+            return {
+                "NW": (top_left, sum_top_left),
+                "SW": (bottom_left, sum_bottom_left),
+                "NE": (top_right, sum_top_right),
+                "SE": (bottom_right, sum_bottom_right),
+            }, (sum_left, sum_right)
+
+        rects: List[Dict[str, float]] = []
+
+        def draw(items, x, y, width, height):
+            total = sum(value for _, value in items)
+            if not items or total <= 0:
+                return
+            if len(items) == 1:
+                label, val = items[0]
+                rects.append({"label": label, "value": val, "x": x, "y": y, "w": width, "h": height})
+                return
+            groups, (sum_left, sum_right) = greedy_split_4(items)
+            left_fraction = sum_left / total if total else 0.5
+            split_x = width * left_fraction
+            top_fraction_left = groups["NW"][1] / sum_left if sum_left else 0.5
+            top_fraction_right = groups["NE"][1] / sum_right if sum_right else 0.5
+            top_height_left = height * top_fraction_left
+            bottom_height_left = height - top_height_left
+            top_height_right = height * top_fraction_right
+            bottom_height_right = height - top_height_right
+            draw(groups["NW"][0], x, y + height - top_height_left, split_x, top_height_left)
+            draw(groups["SW"][0], x, y, split_x, bottom_height_left)
+            draw(
+                groups["NE"][0],
+                x + split_x,
+                y + height - top_height_right,
+                width - split_x,
+                top_height_right,
+            )
+            draw(groups["SE"][0], x + split_x, y, width - split_x, bottom_height_right)
+
+        draw(items, 0.0, 0.0, 1.0, 1.0)
+
+        data = {
+            "cx": [r["x"] + r["w"] / 2 for r in rects],
+            "cy": [r["y"] + r["h"] / 2 for r in rects],
+            "w": [r["w"] for r in rects],
+            "h": [r["h"] for r in rects],
+            "payee": [r["label"] for r in rects],
+            "amount": [r["value"] for r in rects],
+        }
+        total_amount = sum(data["amount"])
+        data["percent"] = [v / total_amount * 100 if total_amount else 0 for v in data["amount"]]
+
+        source = ColumnDataSource(data)
+        low = min(data["amount"]) if data["amount"] else 0
+        high = max(data["amount"]) if data["amount"] else 1
+        color_map = linear_cmap("amount", Viridis256, low, high)
+        p = figure(width=960, height=600, x_range=(0, 1), y_range=(0, 1),
+                   toolbar_location="above", tools="pan,wheel_zoom,reset,save",
+                   outline_line_color=None, title=None)
+        p.rect(x="cx", y="cy", width="w", height="h", source=source,
+               line_color="white", line_width=1, fill_color=color_map, fill_alpha=0.9)
+        hover = HoverTool(tooltips=[("Payee", "@payee"),
+                                    ("Total", "@amount{$0,0}"),
+                                    ("% of total", "@percent{0.0}%")])
+        p.add_tools(hover)
+        p.xgrid.grid_line_color = None
+        p.ygrid.grid_line_color = None
+
+        output_file(out_path, title="Payees by Dollar Amount")
+        save(p)
 
     @staticmethod
     def sanity(entries: List[CheckEntry]) -> Dict[str, object]:
@@ -442,7 +509,10 @@ def main() -> None:
     ap.add_argument("pdf", type=Path, help="Agenda Packet PDF path")
     ap.add_argument("--csv", type=Path, default=Path("checks.csv"), help="Output CSV path")
     ap.add_argument("--json", type=Path, default=None, help="Optional JSON output path")
-    ap.add_argument("--html", type=Path, default=None, help="Optional payee treemap HTML path")
+    ap.add_argument(
+        "--html", type=Path, default=None,
+        help="Optional payee quadtree HTML path"
+    )
     ap.add_argument("--drop-voided", action="store_true", help="Exclude voided/voided-reissued rows from output")
     ap.add_argument("--print-rollups", action="store_true", help="Print per-month rollups after parsing")
     args = ap.parse_args()
@@ -455,7 +525,7 @@ def main() -> None:
     if args.json:
         CheckRegisterParser.write_json(entries, args.json)
     if args.html:
-        CheckRegisterParser.write_payee_treemap_html(entries, args.html)
+        CheckRegisterParser.write_payee_quadtree_html(entries, args.html)
 
     # Stats
     stats = CheckRegisterParser.sanity(entries)


### PR DESCRIPTION
## Summary
- replace D3 treemap with Bokeh-based payee quadtree
- color rectangles by amount and expose quadtree via `--html`
- document new quadtree feature and suppress pdfminer warnings
- treat Bokeh like any other dependency, removing special-case notes

## Testing
- `source codex-wheel-build/bin/activate && python check_register_parser.py ECPackets/2025/'Agenda Packet (rev. 3.18.2025).pdf' --csv out.csv --html payees.html`


------
https://chatgpt.com/codex/tasks/task_e_68a7d2647c9483229620687fe2669752