### PR TITLE
Improve payee/description splitting heuristics

### DIFF
--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -114,22 +114,6 @@ class CheckRegisterParser:
         if not block:
             return "", ""
 
-        tokens = block.split()
-        i = 0
-        letters: List[str] = []
-        while i < len(tokens):
-            tok = tokens[i]
-            stripped = tok.rstrip(".,")
-            if len(stripped) == 1 and stripped.isalpha():
-                letters.append(stripped)
-                i += 1
-            else:
-                break
-        if len(letters) > 1:
-            tokens = ["".join(letters)] + tokens[i:]
-        if len(tokens) == 1:
-            return tokens[0], ""
-
         STOPWORDS = {
             "MERCHANT", "OFFICE", "MEDICAL", "LEGAL", "SUPPLIES", "SERVICE",
             "SERVICES", "EXPENSE", "FEE", "PAYMENT", "RE", "RE:", "TOTAL",
@@ -151,6 +135,29 @@ class CheckRegisterParser:
         ]
 
         SUFFIXES = {"LLP", "LLC", "INC", "CORP", "CO", "COMPANY", "LTD", "ASSOCIATES"}
+        PREFIX_SET = {p.upper() for p in KNOWN_PREFIXES}
+
+        tokens = block.split()
+        if not tokens:
+            return "", ""
+
+        i = 0
+        letters: List[str] = []
+        while i < len(tokens):
+            tok = tokens[i]
+            stripped = tok.rstrip(".,")
+            if len(stripped) == 1 and stripped.isalpha():
+                letters.append(stripped.upper())
+                i += 1
+            else:
+                break
+        if len(letters) > 1:
+            joined = "".join(letters)
+            if joined in PREFIX_SET:
+                tokens = [joined] + tokens[i:]
+
+        if len(tokens) == 1:
+            return tokens[0], ""
 
         # Helper to accumulate weighted votes for boundaries between tokens.
         scores = [0] * (len(tokens))  # index == boundary after tokens[i-1]

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,10 +1,50 @@
 #!/usr/bin/env bash
-# Set up Python environment for offline Codex use
-python3.11 -m venv codex-wheel-build
-source codex-wheel-build/bin/activate
-case "$(uname)" in
-  Linux*) wheel_dir="wheels-linux" ;;
-  Darwin*) wheel_dir="wheels-mac" ;;
-  *) echo "Unsupported OS"; exit 1 ;;
+set -Eeuo pipefail
+
+VENV_DIR="${VENV_DIR:-codex-wheel-build}"
+
+# --- Pick wheel dir based on OS ---
+case "$(uname -s)" in
+  Darwin) WHEEL_DIR="vendor/wheels-mac" ;;
+  Linux)  WHEEL_DIR="vendor/wheels-linux" ;;
+  *)
+    echo "ERROR: Unsupported OS $(uname -s)"
+    exit 1
+    ;;
 esac
-pip install --no-index --find-links "vendor/${wheel_dir}" -r requirements.txt
+
+# --- Robust guard: require CPython 3.11.x ---
+python3 - <<'PY'
+import sys, platform
+if sys.version_info.major != 3 or sys.version_info.minor != 11:
+    raise SystemExit(
+        f"ERROR: Expected Python 3.11.x, found {sys.version.split()[0]}"
+    )
+print("Interpreter OK:", sys.version, sys.executable, platform.platform())
+PY
+
+# --- Fresh venv ---
+rm -rf "$VENV_DIR"
+python3.11 -m venv "$VENV_DIR"
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+# --- Strict offline pip flags ---
+export PIP_NO_INDEX=1
+export PIP_DISABLE_PIP_VERSION_CHECK=1
+export PIP_PROGRESS_BAR=off
+
+# --- Install requirements from local wheelhouse only ---
+python -m pip install -q \
+  --find-links "$WHEEL_DIR" \
+  --only-binary=:all: \
+  --no-build-isolation \
+  -r requirements.txt
+
+# --- Minimal debug info ---
+python - <<'PY'
+import sys, platform
+print("Setup complete with:", sys.version.split()[0], "->", sys.executable, "|", platform.platform())
+PY
+
+echo "Activate with: source $VENV_DIR/bin/activate"


### PR DESCRIPTION
## Summary
- Add and augment splitting heuristics

## Testing
- `./codex_setup.sh`
- `python check_register_parser.py "ECPackets/2025/Agenda Packet (8.19.2025).pdf" --csv out.csv`


------
https://chatgpt.com/codex/tasks/task_e_68a7dedec5bc8322a1f3ebc016ec47aa