### PR TITLE
Prefer Python 3.11 in setup script and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,10 @@ This repo contains an offline parser for El Cerrito agenda packets. To work with
 
 ## Python environment
 
-Use the provided `codex_setup.sh` script to create a Python 3.11 virtual environment and install wheels without network access:
+Use the provided `codex_setup.sh` script to create a Python 3.11 virtual environment and install wheels without network access. When multiple Python versions are installed, prefer the `python3.11` interpreter explicitly:
 
 ```bash
-./codex_setup.sh
+./codex_setup.sh  # uses python3.11 internally
 ```
 
 The script creates a `codex-wheel-build` environment and installs from `vendor/wheels-linux` (or `vendor/wheels-mac` on macOS).  If you wish to do it manually:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ The parser requires `pdfplumber` for table extraction.  After running, the scrip
 prints the number of checks parsed and the total disbursed amount as a basic
 sanity check.
 
+## Setup
+
+This project targets CPython **3.11**. If your system provides multiple Python
+versions, invoke the `python3.11` interpreter explicitly. The included
+`codex_setup.sh` script creates an offline virtual environment using that
+interpreter:
+
+```bash
+./codex_setup.sh
+source codex-wheel-build/bin/activate
+```
+
+The virtual environment installs dependencies from the `vendor/` wheelhouse
+without requiring network access.
+
 ## Tests
 
 Regression and unit tests reside in the `tests/` directory.  Run them with:

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -14,9 +14,15 @@ case "$(uname -s)" in
 esac
 
 # --- Robust guard: require CPython 3.11.x ---
-python3 - <<'PY'
+PYTHON_BIN="${PYTHON_BIN:-python3.11}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "ERROR: python3.11 not found in PATH. Install Python 3.11 and rerun."
+  exit 1
+fi
+
+"$PYTHON_BIN" - <<'PY'
 import sys, platform
-if sys.version_info.major != 3 or sys.version_info.minor != 11:
+if sys.version_info[:2] != (3, 11):
     raise SystemExit(
         f"ERROR: Expected Python 3.11.x, found {sys.version.split()[0]}"
     )
@@ -25,7 +31,7 @@ PY
 
 # --- Fresh venv ---
 rm -rf "$VENV_DIR"
-python3.11 -m venv "$VENV_DIR"
+"$PYTHON_BIN" -m venv "$VENV_DIR"
 # shellcheck disable=SC1091
 source "$VENV_DIR/bin/activate"
 


### PR DESCRIPTION
## Summary
- Ensure `codex_setup.sh` explicitly uses python3.11 and errors if missing
- Document the python3.11 requirement in AGENTS and README so agents choose the right interpreter

## Testing
- `./codex_setup.sh`
- `python check_register_parser.py ECPackets/2025/"Agenda Packet (8.19.2025).pdf" --csv out.csv --pdf-out register.pdf`
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a8a6ce050083228ff17cbc0855db11