### PR TITLE
Refactor check register modules for modularity

### DIFF
--- a/check_register/__init__.py
+++ b/check_register/__init__.py
@@ -1,1 +1,4 @@
-from .parser import CheckEntry, CheckRegisterParser
+from .models import CheckEntry
+from .parser import CheckRegisterParser
+from .outputs import write_csv, write_json, write_payee_quadtree_html
+from .stats import sanity, month_rollups

--- a/check_register/models.py
+++ b/check_register/models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass
+class CheckEntry:
+    section_month: int           # e.g., 6 for June, 7 for July
+    section_year: int            # e.g., 2025
+    ap_type: str                 # "check" or "eft"
+    number: str                  # keep as str to preserve leading zeros
+    date: str                    # MM/DD/YYYY as text (packet uses this)
+    status: str                  # Open / Voided / Voided/Reissued / etc.
+    source: str                  # usually "Accounts Payable"
+    payee: str
+    description: str
+    amount: Decimal
+    voided: bool                 # True if VOID/Voided appears

--- a/check_register/outputs.py
+++ b/check_register/outputs.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import asdict
+from decimal import Decimal
+from pathlib import Path
+from typing import Dict, List
+
+from .models import CheckEntry
+
+
+def write_csv(entries: List[CheckEntry], out_path: Path) -> None:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f, lineterminator="\n")
+        w.writerow([
+            "section_month", "section_year", "ap_type", "number", "date",
+            "status", "source", "payee", "description", "amount", "voided"
+        ])
+        for e in entries:
+            w.writerow([
+                e.section_month, e.section_year, e.ap_type, e.number, e.date,
+                e.status, e.source, e.payee, e.description,
+                f"{e.amount:.2f}", "Y" if e.voided else "N"
+            ])
+
+
+def write_json(entries: List[CheckEntry], out_path: Path) -> None:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(
+            [
+                {**asdict(e), "amount": float(e.amount)}  # JSON-friendly
+                for e in entries
+            ],
+            f,
+            ensure_ascii=False,
+            indent=2,
+        )
+
+
+def write_payee_quadtree_html(entries: List[CheckEntry], out_path: Path) -> None:
+    """Write an HTML quadtree of payees sized by total dollar amount.
+
+    Rectangles are colored using a linear ramp so larger dollar amounts
+    stand out.
+    """
+    from bokeh.models import ColumnDataSource, HoverTool
+    from bokeh.palettes import Viridis256
+    from bokeh.plotting import figure, output_file, save
+    from bokeh.transform import linear_cmap
+
+    totals: Dict[str, Decimal] = {}
+    for e in entries:
+        if e.voided:
+            continue
+        totals[e.payee] = totals.get(e.payee, Decimal("0.00")) + e.amount
+
+    items = [(name, float(amount)) for name, amount in totals.items() if float(amount) > 0]
+
+    def greedy_split_2(items):
+        left_group, right_group, sum_left, sum_right = [], [], 0.0, 0.0
+        for label, weight in sorted(items, key=lambda t: t[1], reverse=True):
+            if sum_left <= sum_right:
+                left_group.append((label, weight))
+                sum_left += weight
+            else:
+                right_group.append((label, weight))
+                sum_right += weight
+        return left_group, right_group, sum_left, sum_right
+
+    def greedy_split_4(items):
+        left_items, right_items, sum_left, sum_right = greedy_split_2(items)
+        top_left, bottom_left, sum_top_left, sum_bottom_left = (
+            greedy_split_2(left_items) if left_items else ([], [], 0, 0)
+        )
+        top_right, bottom_right, sum_top_right, sum_bottom_right = (
+            greedy_split_2(right_items) if right_items else ([], [], 0, 0)
+        )
+        return {
+            "NW": (top_left, sum_top_left),
+            "SW": (bottom_left, sum_bottom_left),
+            "NE": (top_right, sum_top_right),
+            "SE": (bottom_right, sum_bottom_right),
+        }, (sum_left, sum_right)
+
+    rects: List[Dict[str, float]] = []
+
+    def draw(items, x, y, width, height):
+        total = sum(value for _, value in items)
+        if not items or total <= 0:
+            return
+        if len(items) == 1:
+            label, val = items[0]
+            rects.append({"label": label, "value": val, "x": x, "y": y, "w": width, "h": height})
+            return
+        groups, (sum_left, sum_right) = greedy_split_4(items)
+        left_fraction = sum_left / total if total else 0.5
+        split_x = width * left_fraction
+        top_fraction_left = groups["NW"][1] / sum_left if sum_left else 0.5
+        top_fraction_right = groups["NE"][1] / sum_right if sum_right else 0.5
+        top_height_left = height * top_fraction_left
+        bottom_height_left = height - top_height_left
+        top_height_right = height * top_fraction_right
+        bottom_height_right = height - top_height_right
+        draw(groups["NW"][0], x, y + height - top_height_left, split_x, top_height_left)
+        draw(groups["SW"][0], x, y, split_x, bottom_height_left)
+        draw(
+            groups["NE"][0],
+            x + split_x,
+            y + height - top_height_right,
+            width - split_x,
+            top_height_right,
+        )
+        draw(groups["SE"][0], x + split_x, y, width - split_x, bottom_height_right)
+
+    draw(items, 0.0, 0.0, 1.0, 1.0)
+
+    data = {
+        "cx": [r["x"] + r["w"] / 2 for r in rects],
+        "cy": [r["y"] + r["h"] / 2 for r in rects],
+        "w": [r["w"] for r in rects],
+        "h": [r["h"] for r in rects],
+        "payee": [r["label"] for r in rects],
+        "amount": [r["value"] for r in rects],
+    }
+    total_amount = sum(data["amount"])
+    data["percent"] = [v / total_amount * 100 if total_amount else 0 for v in data["amount"]]
+
+    source = ColumnDataSource(data)
+    low = min(data["amount"]) if data["amount"] else 0
+    high = max(data["amount"]) if data["amount"] else 1
+    color_map = linear_cmap("amount", Viridis256, low, high)
+    p = figure(width=960, height=600, x_range=(0, 1), y_range=(0, 1),
+               toolbar_location="above", tools="pan,wheel_zoom,reset,save",
+               outline_line_color=None, title=None)
+    p.rect(x="cx", y="cy", width="w", height="h", source=source,
+           line_color="white", line_width=1, fill_color=color_map, fill_alpha=0.9)
+    hover = HoverTool(tooltips=[("Payee", "@payee"),
+                                ("Total", "@amount{$0,0}"),
+                                ("% of total", "@percent{0.0}%")])
+    p.add_tools(hover)
+    p.xgrid.grid_line_color = None
+    p.ygrid.grid_line_color = None
+
+    output_file(out_path, title="Payees by Dollar Amount")
+    save(p)

--- a/check_register/parser.py
+++ b/check_register/parser.py
@@ -5,36 +5,16 @@ Core logic for extracting "Monthly Disbursement and Check Register" entries from
 
 from __future__ import annotations
 
-import csv
-import json
 import re
 import logging
-from dataclasses import dataclass, asdict
 from decimal import Decimal
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import pdfplumber
 
 from payee_splitter import split_payee_desc_block
-
-
-# ------------------------------
-# Data model
-# ------------------------------
-@dataclass
-class CheckEntry:
-    section_month: int           # e.g., 6 for June, 7 for July
-    section_year: int            # e.g., 2025
-    ap_type: str                 # "check" or "eft"
-    number: str                  # keep as str to preserve leading zeros
-    date: str                    # MM/DD/YYYY as text (packet uses this)
-    status: str                  # Open / Voided / Voided/Reissued / etc.
-    source: str                  # usually "Accounts Payable"
-    payee: str
-    description: str
-    amount: Decimal
-    voided: bool                 # True if VOID/Voided appears
+from .models import CheckEntry
 
 
 # ------------------------------
@@ -206,181 +186,5 @@ class CheckRegisterParser:
 
         return entries
 
-    # ---------- output utilities ----------
-    @staticmethod
-    def write_csv(entries: List[CheckEntry], out_path: Path) -> None:
-        out_path = Path(out_path)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        with out_path.open("w", newline="", encoding="utf-8") as f:
-            w = csv.writer(f, lineterminator="\n")
-            w.writerow([
-                "section_month", "section_year", "ap_type", "number", "date",
-                "status", "source", "payee", "description", "amount", "voided"
-            ])
-            for e in entries:
-                w.writerow([
-                    e.section_month, e.section_year, e.ap_type, e.number, e.date,
-                    e.status, e.source, e.payee, e.description,
-                    f"{e.amount:.2f}", "Y" if e.voided else "N"
-                ])
-
-    @staticmethod
-    def write_json(entries: List[CheckEntry], out_path: Path) -> None:
-        out_path = Path(out_path)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        with out_path.open("w", encoding="utf-8") as f:
-            json.dump(
-                [
-                    {
-                        **asdict(e),
-                        "amount": float(e.amount)  # JSON-friendly
-                    } for e in entries
-                ],
-                f,
-                ensure_ascii=False,
-                indent=2
-            )
-
-    @staticmethod
-    def write_payee_quadtree_html(entries: List[CheckEntry], out_path: Path) -> None:
-        """Write an HTML quadtree of payees sized by total dollar amount.
-
-        Rectangles are colored using a linear ramp so larger dollar amounts
-        stand out.
-        """
-
-        from bokeh.plotting import figure, output_file, save
-        from bokeh.models import ColumnDataSource, HoverTool
-        from bokeh.transform import linear_cmap
-        from bokeh.palettes import Viridis256
-
-        totals: Dict[str, Decimal] = {}
-        for e in entries:
-            if e.voided:
-                continue
-            totals[e.payee] = totals.get(e.payee, Decimal("0.00")) + e.amount
-
-        items = [(name, float(amount)) for name, amount in totals.items() if float(amount) > 0]
-
-        def greedy_split_2(items):
-            left_group, right_group, sum_left, sum_right = [], [], 0.0, 0.0
-            for label, weight in sorted(items, key=lambda t: t[1], reverse=True):
-                if sum_left <= sum_right:
-                    left_group.append((label, weight))
-                    sum_left += weight
-                else:
-                    right_group.append((label, weight))
-                    sum_right += weight
-            return left_group, right_group, sum_left, sum_right
-
-        def greedy_split_4(items):
-            left_items, right_items, sum_left, sum_right = greedy_split_2(items)
-            top_left, bottom_left, sum_top_left, sum_bottom_left = (
-                greedy_split_2(left_items) if left_items else ([], [], 0, 0)
-            )
-            top_right, bottom_right, sum_top_right, sum_bottom_right = (
-                greedy_split_2(right_items) if right_items else ([], [], 0, 0)
-            )
-            return {
-                "NW": (top_left, sum_top_left),
-                "SW": (bottom_left, sum_bottom_left),
-                "NE": (top_right, sum_top_right),
-                "SE": (bottom_right, sum_bottom_right),
-            }, (sum_left, sum_right)
-
-        rects: List[Dict[str, float]] = []
-
-        def draw(items, x, y, width, height):
-            total = sum(value for _, value in items)
-            if not items or total <= 0:
-                return
-            if len(items) == 1:
-                label, val = items[0]
-                rects.append({"label": label, "value": val, "x": x, "y": y, "w": width, "h": height})
-                return
-            groups, (sum_left, sum_right) = greedy_split_4(items)
-            left_fraction = sum_left / total if total else 0.5
-            split_x = width * left_fraction
-            top_fraction_left = groups["NW"][1] / sum_left if sum_left else 0.5
-            top_fraction_right = groups["NE"][1] / sum_right if sum_right else 0.5
-            top_height_left = height * top_fraction_left
-            bottom_height_left = height - top_height_left
-            top_height_right = height * top_fraction_right
-            bottom_height_right = height - top_height_right
-            draw(groups["NW"][0], x, y + height - top_height_left, split_x, top_height_left)
-            draw(groups["SW"][0], x, y, split_x, bottom_height_left)
-            draw(
-                groups["NE"][0],
-                x + split_x,
-                y + height - top_height_right,
-                width - split_x,
-                top_height_right,
-            )
-            draw(groups["SE"][0], x + split_x, y, width - split_x, bottom_height_right)
-
-        draw(items, 0.0, 0.0, 1.0, 1.0)
-
-        data = {
-            "cx": [r["x"] + r["w"] / 2 for r in rects],
-            "cy": [r["y"] + r["h"] / 2 for r in rects],
-            "w": [r["w"] for r in rects],
-            "h": [r["h"] for r in rects],
-            "payee": [r["label"] for r in rects],
-            "amount": [r["value"] for r in rects],
-        }
-        total_amount = sum(data["amount"])
-        data["percent"] = [v / total_amount * 100 if total_amount else 0 for v in data["amount"]]
-
-        source = ColumnDataSource(data)
-        low = min(data["amount"]) if data["amount"] else 0
-        high = max(data["amount"]) if data["amount"] else 1
-        color_map = linear_cmap("amount", Viridis256, low, high)
-        p = figure(width=960, height=600, x_range=(0, 1), y_range=(0, 1),
-                   toolbar_location="above", tools="pan,wheel_zoom,reset,save",
-                   outline_line_color=None, title=None)
-        p.rect(x="cx", y="cy", width="w", height="h", source=source,
-               line_color="white", line_width=1, fill_color=color_map, fill_alpha=0.9)
-        hover = HoverTool(tooltips=[("Payee", "@payee"),
-                                    ("Total", "@amount{$0,0}"),
-                                    ("% of total", "@percent{0.0}%")])
-        p.add_tools(hover)
-        p.xgrid.grid_line_color = None
-        p.ygrid.grid_line_color = None
-
-        output_file(out_path, title="Payees by Dollar Amount")
-        save(p)
-
-    @staticmethod
-    def sanity(entries: List[CheckEntry]) -> Dict[str, object]:
-        """
-        Basic stats by type, and total excluding voided rows.
-        """
-        cnt = len(entries)
-        by_type = {"check": 0, "eft": 0}
-        total = Decimal("0.00")
-        for e in entries:
-            by_type[e.ap_type] = by_type.get(e.ap_type, 0) + 1
-            if not e.voided:
-                total += e.amount
-        return {"count": cnt, "by_type": by_type, "total_nonvoid": total}
-
-    @staticmethod
-    def month_rollups(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Dict[str, Decimal]]:
-        """
-        Returns {(month, year): {"checks": Decimal, "efts": Decimal, "grand": Decimal}}
-        excluding voided rows in sums.
-        """
-        out: Dict[Tuple[int, int], Dict[str, Decimal]] = {}
-        for e in entries:
-            key = (e.section_month, e.section_year)
-            if key not in out:
-                out[key] = {"checks": Decimal("0.00"), "efts": Decimal("0.00"), "grand": Decimal("0.00")}
-            if not e.voided:
-                if e.ap_type == "check":
-                    out[key]["checks"] += e.amount
-                elif e.ap_type == "eft":
-                    out[key]["efts"] += e.amount
-                out[key]["grand"] += e.amount
-        return out
 
 

--- a/check_register/stats.py
+++ b/check_register/stats.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict, List, Tuple
+
+from .models import CheckEntry
+
+
+def sanity(entries: List[CheckEntry]) -> Dict[str, object]:
+    """Basic stats by type, and total excluding voided rows."""
+    cnt = len(entries)
+    by_type = {"check": 0, "eft": 0}
+    total = Decimal("0.00")
+    for e in entries:
+        by_type[e.ap_type] = by_type.get(e.ap_type, 0) + 1
+        if not e.voided:
+            total += e.amount
+    return {"count": cnt, "by_type": by_type, "total_nonvoid": total}
+
+
+def month_rollups(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Dict[str, Decimal]]:
+    """Returns {(month, year): {"checks": Decimal, "efts": Decimal, "grand": Decimal}}
+    excluding voided rows in sums."""
+    out: Dict[Tuple[int, int], Dict[str, Decimal]] = {}
+    for e in entries:
+        key = (e.section_month, e.section_year)
+        if key not in out:
+            out[key] = {"checks": Decimal("0.00"), "efts": Decimal("0.00"), "grand": Decimal("0.00")}
+        if not e.voided:
+            if e.ap_type == "check":
+                out[key]["checks"] += e.amount
+            elif e.ap_type == "eft":
+                out[key]["efts"] += e.amount
+            out[key]["grand"] += e.amount
+    return out

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -6,7 +6,14 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from check_register import CheckRegisterParser
+from check_register import (
+    CheckRegisterParser,
+    month_rollups,
+    sanity,
+    write_csv,
+    write_json,
+    write_payee_quadtree_html,
+)
 from check_register.page_extractor import extract_check_register_pdf
 
 
@@ -32,13 +39,13 @@ def main() -> None:
         entries = parser.extract()
 
         if args.csv:
-            CheckRegisterParser.write_csv(entries, args.csv)
+            write_csv(entries, args.csv)
         if args.json:
-            CheckRegisterParser.write_json(entries, args.json)
+            write_json(entries, args.json)
         if args.html:
-            CheckRegisterParser.write_payee_quadtree_html(entries, args.html)
+            write_payee_quadtree_html(entries, args.html)
 
-        stats = CheckRegisterParser.sanity(entries)
+        stats = sanity(entries)
         print(
             f"Rows: {stats['count']}  (checks={stats['by_type'].get('check', 0)}, "
             f"efts={stats['by_type'].get('eft', 0)})"
@@ -51,7 +58,7 @@ def main() -> None:
         if args.html:
             print(f"HTML: {args.html}")
         if args.print_rollups:
-            roll = CheckRegisterParser.month_rollups(entries)
+            roll = month_rollups(entries)
             if not roll:
                 print("No month rollups to display.")
             else:

--- a/tests/test_register_stats.py
+++ b/tests/test_register_stats.py
@@ -1,0 +1,28 @@
+import unittest
+from decimal import Decimal
+
+from check_register import CheckEntry, month_rollups, sanity
+
+
+class TestRegisterStats(unittest.TestCase):
+    def setUp(self):
+        self.entries = [
+            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "A", "", Decimal("100.00"), False),
+            CheckEntry(6, 2025, "eft", "2", "06/02/2025", "Open", "Accounts Payable", "B", "", Decimal("200.00"), False),
+            CheckEntry(7, 2025, "check", "3", "07/01/2025", "Open", "Accounts Payable", "C", "", Decimal("300.00"), True),
+        ]
+
+    def test_sanity(self):
+        stats = sanity(self.entries)
+        self.assertEqual(stats["count"], 3)
+        self.assertEqual(stats["by_type"], {"check": 2, "eft": 1})
+        self.assertEqual(stats["total_nonvoid"], Decimal("300.00"))
+
+    def test_month_rollups(self):
+        roll = month_rollups(self.entries)
+        self.assertIn((6, 2025), roll)
+        self.assertIn((7, 2025), roll)
+        self.assertEqual(roll[(6, 2025)]["checks"], Decimal("100.00"))
+        self.assertEqual(roll[(6, 2025)]["efts"], Decimal("200.00"))
+        self.assertEqual(roll[(6, 2025)]["grand"], Decimal("300.00"))
+        self.assertEqual(roll[(7, 2025)]["grand"], Decimal("0.00"))


### PR DESCRIPTION
## Summary
- isolate CheckEntry dataclass into dedicated `models` module
- extract CSV/JSON/HTML writers and stats helpers into `outputs` and `stats` modules
- update CLI to consume new helpers and add unit tests for register stats

## Testing
- `python -m unittest discover -s tests`
- `python check_register_parser.py ECPackets/2025/"Agenda Packet (8.19.2025).pdf" --csv out.csv`


------
https://chatgpt.com/codex/tasks/task_e_68a8b0fefc848322b5edfa59a911a9fe