### PR TITLE
Handle missing check register PDFs gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ python check_register_parser.py path/to/Agenda\ Packet.pdf --csv output.csv --ht
 ```
 
 If ``--pdf`` is provided without a filename the register pages are written to
-``CheckRegisterArchive/<year>/`` using names like ``YYYY-MM-register.pdf`` or
+the current working directory using names like ``YYYY-MM-register.pdf`` or
 ``YYYY-MM-MM-register.pdf`` for multi-month registers.
 
 The parser requires `pdfplumber` for table extraction.  After running, the script

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
 
 from check_register import (
     CheckRegisterParser,
@@ -29,10 +30,7 @@ def main() -> None:
     ap.add_argument("--print-rollups", action="store_true", help="Print per-month rollups after parsing")
     ap.add_argument(
         "--pdf", nargs="?", type=Path, const=True, dest="pdf_out", default=None,
-        help=(
-            "Write check register pages to a PDF; if no filename is given, "
-            "a default archive name is used"
-        ),
+        help="Extract check register pages to a PDF",
     )
     args = ap.parse_args()
 
@@ -78,8 +76,18 @@ def main() -> None:
                         )
 
     if args.pdf_out:
-        out_path = default_pdf_name(entries) if args.pdf_out is True else args.pdf_out
-        start, end = extract_check_register_pdf(args.pdf, out_path)
+        if args.pdf_out is True:
+            out_path = default_pdf_name(entries)
+            if out_path is None:
+                print("No check register entries found; PDF not created")
+                sys.exit(1)
+        else:
+            out_path = args.pdf_out
+        try:
+            start, end = extract_check_register_pdf(args.pdf, out_path)
+        except ValueError as exc:
+            print(f"PDF extraction failed: {exc}")
+            sys.exit(1)
         print(f"PDF: {out_path} (pages {start}-{end})")
 
 

--- a/tests/test_cli_pdf.py
+++ b/tests/test_cli_pdf.py
@@ -1,0 +1,59 @@
+import contextlib
+import io
+import tempfile
+from decimal import Decimal
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+import pypdfium2 as pdfium
+
+from check_register.models import CheckEntry
+from check_register.page_extractor import default_pdf_name
+from check_register_parser import main
+
+
+class TestCliPdf(unittest.TestCase):
+    def _empty_pdf(self, path: Path) -> None:
+        doc = pdfium.PdfDocument.new()
+        doc.new_page(1, 1)
+        doc.save(str(path))
+
+    def test_default_pdf_name_multi_month(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "", "", "", "", "", "", Decimal("0"), False),
+            CheckEntry(7, 2025, "check", "", "", "", "", "", "", Decimal("0"), False),
+        ]
+        out = default_pdf_name(entries)
+        self.assertEqual(out, Path("2025-06-07-register.pdf"))
+
+    def test_default_pdf_name_single_month(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "", "", "", "", "", "", Decimal("0"), False)
+        ]
+        out = default_pdf_name(entries)
+        self.assertEqual(out, Path("2025-06-register.pdf"))
+
+    def test_default_pdf_name_empty(self):
+        self.assertIsNone(default_pdf_name([]))
+
+    def test_pdf_no_register_graceful(self):
+        pdf_path = Path(tempfile.mkstemp(suffix=".pdf")[1])
+        self._empty_pdf(pdf_path)
+        argv = ["check_register_parser.py", str(pdf_path), "--pdf"]
+        try:
+            with patch("sys.argv", argv):
+                with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+                    with self.assertRaises(SystemExit) as cm:
+                        main()
+                    output = buf.getvalue()
+            self.assertEqual(cm.exception.code, 1)
+            self.assertIn("No check register entries found", output)
+        finally:
+            if pdf_path.exists():
+                pdf_path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_page_extractor.py
+++ b/tests/test_page_extractor.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 
 import pdfplumber
+import pypdfium2 as pdfium
 
 from check_register.page_extractor import extract_check_register_pdf
 from check_register.parser import CheckRegisterParser
@@ -25,9 +26,13 @@ class TestPageExtractor(unittest.TestCase):
                 )
 
     def test_no_check_register(self):
-        src = Path('ECPackets/2025/Agenda Packet (rev. 4.2.2025).pdf')
         with tempfile.TemporaryDirectory() as tmpdir:
-            out = Path(tmpdir) / 'register.pdf'
+            tmp = Path(tmpdir)
+            src = tmp / 'empty.pdf'
+            doc = pdfium.PdfDocument.new()
+            doc.new_page(1, 1)
+            doc.save(str(src))
+            out = tmp / 'register.pdf'
             with self.assertRaises(ValueError):
                 extract_check_register_pdf(src, out)
 


### PR DESCRIPTION
## Summary
- Avoid placeholder filenames by returning `None` when no check register entries are found
- Exit `--pdf` with a clear message instead of writing `unknown-register.pdf`
- Simplify `--pdf` CLI help now that output defaults to the working directory

## Testing
- `python check_register_parser.py ECPackets/2025/"Agenda Packet (8.19.2025).pdf" --pdf`
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68a95d3bd1748322b9b4f1cbd39a28af