### PR TITLE
docs: clarify codex workflow and repo context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,17 @@
 # AGENTS guidelines
 
-This repo contains an offline parser for El Cerrito agenda packets. To work with the code in a Codex sandbox:
+This repository houses an offline parser that extracts the City of El Cerrito's monthly check register from council agenda packet PDFs. The project ships sample data and pre-built wheels so it runs without network access, including in OpenAI's Codex environment.
 
-## Python environment
+## Codex environment
 
-This repository includes a `.python-version` file that pins Python `3.11` via `pyenv`. If that version is missing, run `pyenv install -s 3.11` before continuing.
-
-Use the provided `scripts/codex_setup.sh` script to create a Python 3.11 virtual environment and install wheels without network access. When multiple Python versions are installed, prefer the `python3.11` interpreter explicitly:
+- Python 3.11 is pinned via `.python-version`. If `pyenv` lacks it, run `pyenv install -s 3.11`.
+- Create a virtual environment with the offline wheels:
 
 ```bash
 ./scripts/codex_setup.sh  # uses python3.11 internally
 ```
 
-The script creates a `codex-wheel-build` environment and installs from `vendor/wheels-linux` (or `vendor/wheels-mac` on macOS).  If you wish to do it manually:
+  or manually:
 
 ```bash
 python -m venv codex-wheel-build
@@ -20,27 +19,41 @@ source codex-wheel-build/bin/activate
 pip install --no-index --find-links vendor/wheels-linux -r requirements.txt
 ```
 
-## Running the parser
+- Keep the working tree clean (`git status --short`) and make small, focused commits.
 
-To generate a CSV from the 2023 statements run:
+## Tests
 
-```bash
-    check_register_parser.py data/originals/2025/"Agenda Packet (8.19.2025).pdf" --csv out.csv
-```
-
-Each PDF should log `✔ reconciled`.  The resulting CSV confirms the parser still works.
-
-## Running tests
-
-Unit tests live under the `tests/` directory.  Run them with:
+Contributions must preserve or improve payee and description extraction accuracy. Run the unit tests:
 
 ```bash
 python -m unittest discover -s tests
 ```
 
-Always execute the test suite before committing changes to ensure payee splitting
-and other behavior remain stable.
+Accuracy tests such as `tests/test_june_2025_payees.py`, `tests/test_jul_aug_2025_top_payees.py`, and `tests/test_payee_splitter.py` enforce these thresholds.
 
-## Streamlining Codex work
+## Testing and artifacts
 
-Always set up the `codex-wheel-build` environment and run the parser command when modifying code so you can verify parsing succeeds without network access.
+If parser changes might affect output, regenerate sample artifacts:
+
+```bash
+for pdf in data/originals/2025/*.pdf; do
+  python scripts/build_register_archive.py "$pdf"
+done
+```
+
+Commit regenerated artifacts in separate commits or pull requests from the code changes that triggered them.
+
+## Data: originals and artifacts
+
+- `data/originals/` holds agenda packet PDFs downloaded from [www.elcerrito.gov](https://www.elcerrito.gov).
+- `data/artifacts/` stores parser outputs such as chunk archives used in tests.
+
+## Running the parser
+
+To generate a CSV from the 2025 statements run:
+
+```bash
+check_register_parser.py data/originals/2025/"Agenda Packet (8.19.2025).pdf" --csv out.csv
+```
+
+Each PDF should log `✔ reconciled`. The resulting CSV confirms the parser still works. Run the parser when modifying code to verify behavior offline.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # ECCheckParser
 
 Utility for extracting the "Monthly Disbursement and Check Register Report"
-from City of El Cerrito council agenda packet PDFs.  The script
-`check_register_parser.py` reads a packet PDF and emits a CSV file containing
-one row per check along with a couple of simple aggregates.  It can also
-produce an HTML quadtree showing payees sized by total dollar amount and
+from City of El Cerrito council agenda packet PDFs. The project targets fully
+offline parsing: source PDFs from [www.elcerrito.gov](https://www.elcerrito.gov)
+reside under `data/originals/`, and parser artifacts used in tests live under
+`data/artifacts/`. Unit tests enforce payee and description extraction fidelity.
+The script `check_register_parser.py` reads a packet PDF and emits a CSV file
+containing one row per check along with a couple of simple aggregates. It can
+also produce an HTML quadtree showing payees sized by total dollar amount and
 optionally extracts the check register pages into a standalone PDF.
 
 Sample agenda packets live under ``data/originals/YYYY/`` with derived


### PR DESCRIPTION
## Summary
- restructure root `AGENTS.md` with separate Codex environment, tests, and artifact regeneration sections
- expand `README.md` with offline data sources and accuracy notes

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68ab586859a48322ab8c6fe5c6327db5