### PR TITLE
feat: capture word coordinates alongside raw lines

### DIFF
--- a/check_register/models.py
+++ b/check_register/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import List
 
@@ -28,3 +28,16 @@ class RowChunk:
     section_year: int
     ap_type: str                 # "check" or "eft"
     lines: List[str]             # original PDF text lines belonging to the row
+
+    # TODO: Explore migrating away from line-based parsing. These positioned
+    # words capture x-coordinates for each token so that future column
+    # detection can rely on geometry rather than normalized spaces.
+    line_words: List[List["PositionedWord"]] = field(default_factory=list)
+
+
+@dataclass
+class PositionedWord:
+    """A single word extracted from the PDF with its starting x position."""
+
+    text: str
+    x0: float


### PR DESCRIPTION
## Summary
- record per-word x positions in `RowChunk` to explore x-coordinate based parsing
- extract pdf words with coordinates in `extract_raw_chunks` and store in chunks

## Testing
- `python -m unittest discover -s tests`
- `python check_register_parser.py data/originals/2025/"Agenda Packet (8.19.2025).pdf" --csv /tmp/out.csv`

## Follow-up
- Regenerate chunk artifacts with `scripts/build_register_archive.py` in a separate PR once the new positional data proves useful


------
https://chatgpt.com/codex/tasks/task_e_68ab7a20f1d883229f75014916fa7ecb