### PR TITLE
Refine x-coordinate clustering for payee/description split

### DIFF
--- a/check_register/parser.py
+++ b/check_register/parser.py
@@ -215,7 +215,24 @@ class CheckRegisterParser:
 
         payee = desc = ""
         if amount is not None:
-            payee, desc = self._split_payee_desc_block(block)
+            result = None
+            if chunk.line_words:
+                try:
+                    from payee_splitter.cluster import split_payee_desc_by_x
+                    from .models import PositionedWord
+
+                    line_words = chunk.line_words
+                    if line_words and isinstance(line_words[0][0], dict):
+                        line_words = [
+                            [PositionedWord(**w) for w in lw] for lw in line_words
+                        ]
+                    result = split_payee_desc_by_x(line_words)
+                except Exception:
+                    result = None
+            if result:
+                payee, desc = result
+            else:
+                payee, desc = self._split_payee_desc_block(block)
 
         return CheckEntry(
             section_month=chunk.section_month,

--- a/payee_splitter/cluster.py
+++ b/payee_splitter/cluster.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+# ``PositionedWord`` is light-weight and importing it at runtime keeps this
+# helper self contained.  The TYPE_CHECKING block avoids circular imports when
+# building docs while still providing type hints during development.
+if TYPE_CHECKING:
+    from check_register.models import PositionedWord
+else:  # pragma: no cover - imported lazily for runtime use
+    from check_register.models import PositionedWord
+
+_AMOUNT_RE = re.compile(r"\$-?\d{1,3}(?:,\d{3})*(?:\.\d{2})?")
+
+
+def _squeeze_letters(tokens: List[PositionedWord]) -> List[PositionedWord]:
+    """Merge runs of single letters into a single token.
+
+    Some payees such as ``P E R S`` have their letters extracted as separate
+    PDF words.  These individual tokens confuse the column split logic because
+    the gaps between letters can exceed the gap to the description column.  We
+    merge adjacent single-letter tokens when their x-distance is tiny to
+    reconstruct the original word.
+    """
+
+    if not tokens:
+        return tokens
+
+    squeezed: List[PositionedWord] = []
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if len(t.text) == 1 and t.text.isalpha():
+            letters = [t.text]
+            x_last = t.x0
+            j = i + 1
+            while (
+                j < len(tokens)
+                and len(tokens[j].text) == 1
+                and tokens[j].text.isalpha()
+                and tokens[j].x0 - x_last <= 6  # small gap indicates same word
+            ):
+                letters.append(tokens[j].text)
+                x_last = tokens[j].x0
+                j += 1
+            if len(letters) > 1:
+                squeezed.append(PositionedWord(text="".join(letters), x0=t.x0))
+                i = j
+                continue
+        squeezed.append(t)
+        i += 1
+    return squeezed
+
+
+def split_payee_desc_by_x(line_words: List[List[PositionedWord]]) -> Optional[Tuple[str, str]]:
+    """Split payee/description using x-coordinate clustering.
+
+    The parser provides ``line_words`` which captures each PDF word and its
+    starting ``x`` position.  Typical check register entries show the payee and
+    description separated into two vertical columns.  By clustering ``x``
+    coordinates we can infer the boundary between the two columns and avoid
+    relying on brittle text heuristics.
+
+    Parameters
+    ----------
+    line_words:
+        Tokenised words for each line with their ``x0`` coordinates.
+
+    Returns
+    -------
+    tuple of (payee, description) or ``None`` if the data doesn't resemble the
+    expected pattern.
+    """
+
+    if not line_words:
+        return None
+
+    # Skip tokens until we encounter the ``Payable`` marker on the first line,
+    # since everything before it is check metadata (number, date, status, etc.).
+    tokens: List[PositionedWord] = []
+    found_payable = False
+    first_line = line_words[0]
+    for w in first_line:
+        if not found_payable:
+            if w.text.upper() == 'PAYABLE':
+                found_payable = True
+            continue
+        tokens.append(w)
+
+    if not found_payable:
+        return None
+
+    # Include all subsequent lines as they belong to payee/description/amount.
+    for lw in line_words[1:]:
+        tokens.extend(lw)
+
+    if not tokens:
+        return None
+
+    # Drop trailing amount token to avoid picking the wide gap before it.
+    if _AMOUNT_RE.fullmatch(tokens[-1].text):
+        tokens = tokens[:-1]
+    if not tokens:
+        return None
+
+    # Merge any single-letter runs to avoid artificial gaps (e.g. ``P E R S``).
+    tokens = _squeeze_letters(tokens)
+
+    # Determine the column boundary by finding the split that minimises the
+    # within-cluster variance of x positions.  This 1D k-means approach is
+    # robust against uneven gaps and does not assume a particular number of
+    # unique x values.
+    xs = sorted(t.x0 for t in tokens)
+    if len(xs) < 2:
+        return None
+
+    best_cost = float("inf")
+    best_thresh = None
+    for i in range(1, len(xs)):
+        left = xs[:i]
+        right = xs[i:]
+        mean_l = sum(left) / len(left)
+        mean_r = sum(right) / len(right)
+        cost = sum((x - mean_l) ** 2 for x in left) + sum((x - mean_r) ** 2 for x in right)
+        if cost < best_cost:
+            best_cost = cost
+            best_thresh = (xs[i - 1] + xs[i]) / 2.0
+
+    if best_thresh is None:
+        return None
+    threshold = best_thresh
+
+    payee_tokens = [t.text for t in tokens if t.x0 <= threshold]
+    desc_tokens = [t.text for t in tokens if t.x0 > threshold]
+
+    payee = " ".join(payee_tokens).rstrip(',').strip()
+    desc = " ".join(desc_tokens).strip()
+
+    if not payee and not desc:
+        return None
+
+    return payee, desc

--- a/tests/test_jul_aug_2025_top_payees.py
+++ b/tests/test_jul_aug_2025_top_payees.py
@@ -25,8 +25,8 @@ class TestJulAug2025TopPayees(unittest.TestCase):
         entries_sorted = sorted(entries, key=lambda e: e.amount, reverse=True)
         payees = [e.payee for e in entries_sorted[: len(PAYEES_JUL_AUG_2025_TOP)]]
         matches = sum(1 for a, b in zip(PAYEES_JUL_AUG_2025_TOP, payees) if a == b)
-        # Baseline as of this commit: 27 matches. Update as heuristics improve.
-        self.assertGreaterEqual(matches, 27,
+        # Baseline as of this commit: 30 matches. Update as heuristics improve.
+        self.assertGreaterEqual(matches, 30,
                                 f"Only {matches} of {len(PAYEES_JUL_AUG_2025_TOP)} payees matched")
 
 

--- a/tests/test_june_2025_payees.py
+++ b/tests/test_june_2025_payees.py
@@ -25,8 +25,9 @@ class TestJune2025Payees(unittest.TestCase):
         payees = [e.payee for e in entries if e.section_month == 6 and e.section_year == 2025]
         payees = payees[: len(PAYEES_JUNE_2025)]
         matches = sum(1 for a, b in zip(PAYEES_JUNE_2025, payees) if a == b)
-        # Baseline as of this commit: 102 matches. Update as heuristics improve.
-        self.assertGreaterEqual(matches, 102, f"Only {matches} of {len(PAYEES_JUNE_2025)} payees matched")
+        # Baseline as of this commit: 154 matches. Update as heuristics improve.
+        self.assertGreaterEqual(matches, 150,
+                                f"Only {matches} of {len(PAYEES_JUNE_2025)} payees matched")
 
 
 if __name__ == "__main__":

--- a/tests/test_parse_chunks_basic.py
+++ b/tests/test_parse_chunks_basic.py
@@ -3,22 +3,77 @@ from pathlib import Path
 from decimal import Decimal
 
 from check_register import CheckRegisterParser, RowChunk
+from check_register.models import PositionedWord
 
 
 class TestParseChunksBasic(unittest.TestCase):
     def test_basic_chunk_parsing(self):
         parser = CheckRegisterParser(Path('dummy'))
+        # ``x0`` positions approximate values from
+        # ``data/artifacts/chunks/2025-04.json`` entry 92736 (VELOCITY LOCK AND
+        # KEY KEYS - CUSTODIAL CLOSET).  Payee tokens cluster around ~290-340 and
+        # description tokens around ~440+.  These synthetic coordinates ensure
+        # tests remain stable even if artifacts are regenerated.
+        line_words = [
+            [
+                PositionedWord(text='1000', x0=7.8),
+                PositionedWord(text='06/01/2025', x0=52.0),
+                PositionedWord(text='Open', x0=85.0),
+                PositionedWord(text='Accounts', x0=214.2),
+                PositionedWord(text='Payable', x0=238.2),
+                PositionedWord(text='CITY', x0=287.6),
+                PositionedWord(text='OF', x0=300.0),
+                PositionedWord(text='RICHMOND', x0=314.0),
+                PositionedWord(text='Fire', x0=444.2),
+                PositionedWord(text='services', x0=460.3),
+                PositionedWord(text='$1,234.56', x0=728.8),
+            ]
+        ]
         chunk = RowChunk(
             section_month=6,
             section_year=2025,
             ap_type='check',
             lines=['1000 06/01/2025 Open Accounts Payable CITY OF RICHMOND Fire services $1,234.56'],
+            line_words=line_words,
         )
         entry = parser.parse_chunks([chunk])[0]
         self.assertEqual(entry.number, '1000')
         self.assertEqual(entry.payee, 'CITY OF RICHMOND')
         self.assertEqual(entry.description, 'Fire services')
         self.assertEqual(entry.amount, Decimal('1234.56'))
+
+    def test_letter_run_squeezed(self):
+        parser = CheckRegisterParser(Path('dummy'))
+        # ``x0`` positions approximate values from
+        # ``data/artifacts/chunks/2025-06-07.json`` entry
+        # "3306 06/13/2025 Open Accounts Payable P E R S PE1% - PERS SEIU*".
+        # The payee letters are extracted individually and should be merged
+        # into "PERS" before splitting the description column.
+        line_words = [
+            [
+                PositionedWord(text='1001', x0=7.8),
+                PositionedWord(text='06/13/2025', x0=52.0),
+                PositionedWord(text='Open', x0=85.0),
+                PositionedWord(text='Accounts', x0=214.2),
+                PositionedWord(text='Payable', x0=238.2),
+                PositionedWord(text='P', x0=285.1),
+                PositionedWord(text='E', x0=290.0),
+                PositionedWord(text='R', x0=295.0),
+                PositionedWord(text='S', x0=300.1),
+                PositionedWord(text='PE1%', x0=446.7),
+                PositionedWord(text='$1.00', x0=728.8),
+            ]
+        ]
+        chunk = RowChunk(
+            section_month=6,
+            section_year=2025,
+            ap_type='check',
+            lines=['1001 06/13/2025 Open Accounts Payable P E R S PE1% $1.00'],
+            line_words=line_words,
+        )
+        entry = parser.parse_chunks([chunk])[0]
+        self.assertEqual(entry.payee, 'PERS')
+        self.assertEqual(entry.description, 'PE1%')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Convert chunk word dictionaries to `PositionedWord` objects before x-based splitting
- Merge single-letter runs and apply 1D k-means on x positions for robust payee/description boundaries
- Raise June 2025 payee and top-payee accuracy thresholds with new regression case for "P E R S"

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68ab87f25cf88322b557dcad691dc36b