### PR TITLE
Refactor parser line handling into helpers

### DIFF
--- a/check_register/parser.py
+++ b/check_register/parser.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import logging
+from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -15,6 +16,15 @@ import pdfplumber
 
 from payee_splitter import split_payee_desc_block
 from .models import CheckEntry, RowChunk, PositionedWord
+
+
+@dataclass
+class _ExtractState:
+    month: Optional[int] = None
+    year: Optional[int] = None
+    mode: Optional[str] = None  # "check" or "eft"
+    lines: List[str] = field(default_factory=list)
+    words: List[List[PositionedWord]] = field(default_factory=list)
 
 
 # ------------------------------
@@ -69,111 +79,126 @@ class CheckRegisterParser:
     def _split_payee_desc_block(block: str) -> Tuple[str, str]:
         return split_payee_desc_block(block)
 
+    def _words_by_line(self, page) -> List[List[PositionedWord]]:
+        """Group pdfplumber words into lines preserving x positions."""
+        words = page.extract_words()
+        words.sort(key=lambda w: w["top"])  # top-to-bottom
+        lines: List[List[PositionedWord]] = []
+        current: List[dict] = []
+        current_top: Optional[float] = None
+        for w in words:
+            top = w["top"]
+            if current_top is None or abs(top - current_top) < 3:  # y tolerance
+                current.append(w)
+                if current_top is None:
+                    current_top = top
+            else:
+                lines.append(
+                    [
+                        PositionedWord(text=pw["text"], x0=pw["x0"])
+                        for pw in sorted(current, key=lambda x: x["x0"])
+                    ]
+                )
+                current = [w]
+                current_top = top
+        if current:
+            lines.append(
+                [
+                    PositionedWord(text=pw["text"], x0=pw["x0"])
+                    for pw in sorted(current, key=lambda x: x["x0"])
+                ]
+            )
+        return lines
+
+    def _handle_line(
+        self, line: str, wl: List[PositionedWord], state: _ExtractState
+    ) -> List[RowChunk]:
+        chunks: List[RowChunk] = []
+        if not line or self._skip_line.match(line):
+            return chunks
+
+        b = self._block_hdr.match(line)
+        if b:
+            if state.lines:
+                chunks.append(
+                    RowChunk(state.month, state.year, state.mode or "check", state.lines, state.words)
+                )
+                state.lines = []
+                state.words = []
+            state.month = int(b.group(4))
+            state.year = int(b.group(6))
+            state.mode = "check"
+            return chunks
+
+        if self._checks_hdr.match(line):
+            if state.lines:
+                chunks.append(
+                    RowChunk(state.month, state.year, state.mode or "check", state.lines, state.words)
+                )
+                state.lines = []
+                state.words = []
+            state.mode = "check"
+            return chunks
+
+        if self._efts_hdr.match(line):
+            if state.lines:
+                chunks.append(
+                    RowChunk(state.month, state.year, state.mode or "check", state.lines, state.words)
+                )
+                state.lines = []
+                state.words = []
+            state.mode = "eft"
+            return chunks
+
+        if state.month is None or state.year is None:
+            return chunks
+
+        if self._row_start.match(line):
+            if state.lines:
+                chunks.append(
+                    RowChunk(state.month, state.year, state.mode or "check", state.lines, state.words)
+                )
+            state.lines = [line]
+            state.words = [wl]
+            if self._amount_tail.search(line):
+                chunks.append(
+                    RowChunk(state.month, state.year, state.mode or "check", state.lines, state.words)
+                )
+                state.lines = []
+                state.words = []
+            return chunks
+
+        if state.lines:
+            state.lines.append(line)
+            state.words.append(wl)
+            if self._amount_tail.search(line):
+                chunks.append(
+                    RowChunk(state.month, state.year, state.mode or "check", state.lines, state.words)
+                )
+                state.lines = []
+                state.words = []
+        return chunks
+
     # ---------- raw extraction ----------
     def extract_raw_chunks(self) -> List[RowChunk]:
         chunks: List[RowChunk] = []
-
-        current_month: Optional[int] = None
-        current_year: Optional[int] = None
-        mode: Optional[str] = None  # "check" or "eft"
-        current_lines: List[str] = []
-        current_words: List[List[PositionedWord]] = []
-
-        def words_by_line(page) -> List[List[PositionedWord]]:
-            """Group pdfplumber words into lines preserving x positions."""
-            words = page.extract_words()
-            words.sort(key=lambda w: w["top"])  # top-to-bottom
-            lines: List[List[PositionedWord]] = []
-            current: List[dict] = []
-            current_top: Optional[float] = None
-            for w in words:
-                top = w["top"]
-                if current_top is None or abs(top - current_top) < 3:  # y tolerance
-                    current.append(w)
-                    if current_top is None:
-                        current_top = top
-                else:
-                    lines.append([PositionedWord(text=pw["text"], x0=pw["x0"]) for pw in sorted(current, key=lambda x: x["x0"])])
-                    current = [w]
-                    current_top = top
-            if current:
-                lines.append([PositionedWord(text=pw["text"], x0=pw["x0"]) for pw in sorted(current, key=lambda x: x["x0"])])
-            return lines
+        state = _ExtractState()
 
         logging.getLogger("pdfminer").setLevel(logging.ERROR)
         with pdfplumber.open(self.pdf_path) as pdf:
             for page in pdf.pages:
                 lines = (page.extract_text() or "").splitlines()
-                word_lines = words_by_line(page)
+                word_lines = self._words_by_line(page)
                 for idx, raw in enumerate(lines):
                     line = raw.rstrip()
                     wl = word_lines[idx] if idx < len(word_lines) else []
+                    for chunk in self._handle_line(line, wl, state):
+                        chunks.append(chunk)
 
-                    if not line or self._skip_line.match(line):
-                        continue
-
-                    b = self._block_hdr.match(line)
-                    if b:
-                        if current_lines:
-                            chunks.append(
-                                RowChunk(current_month, current_year, mode or "check", current_lines, current_words)
-                            )
-                            current_lines = []
-                            current_words = []
-                        current_month = int(b.group(4))
-                        current_year = int(b.group(6))
-                        mode = "check"
-                        continue
-
-                    if self._checks_hdr.match(line):
-                        if current_lines:
-                            chunks.append(
-                                RowChunk(current_month, current_year, mode or "check", current_lines, current_words)
-                            )
-                            current_lines = []
-                            current_words = []
-                        mode = "check"
-                        continue
-
-                    if self._efts_hdr.match(line):
-                        if current_lines:
-                            chunks.append(
-                                RowChunk(current_month, current_year, mode or "check", current_lines, current_words)
-                            )
-                            current_lines = []
-                            current_words = []
-                        mode = "eft"
-                        continue
-
-                    if current_month is None or current_year is None:
-                        continue
-
-                    if self._row_start.match(line):
-                        if current_lines:
-                            chunks.append(
-                                RowChunk(current_month, current_year, mode or "check", current_lines, current_words)
-                            )
-                        current_lines = [line]
-                        current_words = [wl]
-                        if self._amount_tail.search(line):
-                            chunks.append(
-                                RowChunk(current_month, current_year, mode or "check", current_lines, current_words)
-                            )
-                            current_lines = []
-                            current_words = []
-                    else:
-                        if current_lines:
-                            current_lines.append(line)
-                            current_words.append(wl)
-                            if self._amount_tail.search(line):
-                                chunks.append(
-                                    RowChunk(current_month, current_year, mode or "check", current_lines, current_words)
-                                )
-                                current_lines = []
-                                current_words = []
-
-        if current_lines:
-            chunks.append(RowChunk(current_month, current_year, mode or "check", current_lines, current_words))
+        if state.lines:
+            chunks.append(
+                RowChunk(state.month, state.year, state.mode or "check", state.lines, state.words)
+            )
 
         return chunks
 


### PR DESCRIPTION
## Summary
- pull pdf word grouping into `_words_by_line`
- add `_ExtractState` dataclass and `_handle_line` for per-line parsing
- streamline `extract_raw_chunks` around new helpers

## Testing
- `python check_register_parser.py data/originals/2025/"Agenda Packet (8.19.2025).pdf" --csv out.csv`
- `python -m unittest discover -s tests`

Suggested squash merge commit message:
```
refactor parser line handling into helpers
```

------
https://chatgpt.com/codex/tasks/task_e_68ad0af220a483228c74680340ff619d