### PR TITLE
Allow dropping top payees from quadtree

### DIFF
--- a/check_register/outputs.py
+++ b/check_register/outputs.py
@@ -151,11 +151,22 @@ def assemble_quadtree_data(rects: List[Dict[str, float]], payees: Dict[str, List
     return data
 
 
-def build_payee_quadtree_data(entries: List[CheckEntry]) -> Dict[str, List]:
-    """Return ColumnDataSource-friendly data for the payee quadtree."""
+def build_payee_quadtree_data(entries: List[CheckEntry], drop: int = 0) -> Dict[str, List]:
+    """Return ColumnDataSource-friendly data for the payee quadtree.
+
+    Args:
+        entries: Parsed check register entries.
+        drop: Number of highest-dollar payees to exclude from the tree.
+    """
 
     payees = group_payees(entries)
     items = payee_totals(payees)
+    if drop > 0:
+        items.sort(key=lambda t: t[1], reverse=True)
+        removed = {label for label, _ in items[:drop]}
+        items = items[drop:]
+        for r in removed:
+            payees.pop(r, None)
     rects = layout_rectangles(items)
     return assemble_quadtree_data(rects, payees)
 
@@ -223,11 +234,17 @@ def _add_hover(p):
     p.add_tools(hover)
 
 
-def write_payee_quadtree_html(entries: List[CheckEntry], out_path: Path) -> None:
-    """Write an HTML quadtree of payees sized by total dollar amount."""
+def write_payee_quadtree_html(entries: List[CheckEntry], out_path: Path, drop: int = 0) -> None:
+    """Write an HTML quadtree of payees sized by total dollar amount.
+
+    Args:
+        entries: Parsed check register entries.
+        out_path: Destination HTML path.
+        drop: Number of highest-dollar payees to exclude.
+    """
     from bokeh.plotting import output_file, save
 
-    data = build_payee_quadtree_data(entries)
+    data = build_payee_quadtree_data(entries, drop=drop)
     plot = make_quadtree_figure(data)
     output_file(out_path, title="Payees by Dollar Amount")
     save(plot)

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -31,6 +31,7 @@ def main() -> None:
     ap.add_argument("--csv", nargs="?", type=Path, const=True, default=None, help="Output CSV path")
     ap.add_argument("--json", nargs="?", type=Path, const=True, default=None, help="Optional JSON output path")
     ap.add_argument("--html", nargs="?", type=Path, const=True, default=None, help="Optional payee quadtree HTML path")
+    ap.add_argument("--drop", type=int, default=0, help="Drop the N largest payees from the quadtree")
     ap.add_argument("--drop-voided", action="store_true", help="Exclude voided/voided-reissued rows from output")
     ap.add_argument("--print-rollups", action="store_true", help="Print per-month rollups after parsing")
     ap.add_argument(
@@ -88,7 +89,7 @@ def main() -> None:
         if args.json:
             write_json(entries, args.json)
         if args.html:
-            write_payee_quadtree_html(entries, args.html)
+            write_payee_quadtree_html(entries, args.html, drop=args.drop)
 
         if args.csv or args.json or args.html or args.print_rollups:
             stats = sanity(entries)

--- a/tests/test_quadtree_output.py
+++ b/tests/test_quadtree_output.py
@@ -28,6 +28,16 @@ class TestPayeeQuadtreeData(unittest.TestCase):
         data = build_payee_quadtree_data(entries)
         self.assertEqual(data["label"][0], "Alpha Co")
 
+    def test_drop_top_payees(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "CalPERS", "a", Decimal("100.00"), False),
+            CheckEntry(6, 2025, "check", "2", "06/02/2025", "Open", "Accounts Payable", "Alpha", "b", Decimal("60.00"), False),
+            CheckEntry(6, 2025, "check", "3", "06/03/2025", "Open", "Accounts Payable", "Beta", "c", Decimal("50.00"), False),
+        ]
+        data = build_payee_quadtree_data(entries, drop=1)
+        self.assertNotIn("CalPERS", data["payee"])
+        self.assertCountEqual(sorted(data["payee"]), ["Alpha", "Beta"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support excluding the largest payees when building payee quadtrees
- add `--drop` CLI option to pass-through exclusion count
- test dropping highest-dollar payees

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68adf3f1595c832291db4f49cee8b486