### PR TITLE
Display period and totals in payee quadtree title

### DIFF
--- a/check_register/outputs.py
+++ b/check_register/outputs.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import csv
 import json
+from calendar import month_name
 from dataclasses import asdict
+from decimal import Decimal
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -171,7 +173,33 @@ def build_payee_quadtree_data(entries: List[CheckEntry], drop: int = 0) -> Dict[
     return assemble_quadtree_data(rects, payees)
 
 
-def make_quadtree_figure(data: Dict[str, List]):
+def build_payee_quadtree_title(entries: List[CheckEntry], data: Dict[str, List], drop: int = 0) -> str:
+    months = sorted({(e.section_year, e.section_month) for e in entries})
+    if months:
+        sy, sm = months[0]
+        ey, em = months[-1]
+        start = f"{month_name[sm]} {sy}"
+        if (sy, sm) == (ey, em):
+            period = start
+        elif sy == ey:
+            period = f"{month_name[sm]}–{month_name[em]} {sy}"
+        else:
+            period = f"{start}–{month_name[em]} {ey}"
+    else:
+        period = "Unknown period"
+    grand_total = sum((e.amount for e in entries if not e.voided), Decimal("0.00"))
+    shown_payees = set(data["payee"])
+    shown_total = sum(
+        (e.amount for e in entries if not e.voided and e.payee in shown_payees),
+        Decimal("0.00"),
+    )
+    title = f"{period} Checks/EFT Report: ${grand_total:,.2f}"
+    if drop > 0:
+        title += f" (${shown_total:,.2f} shown, top {drop} payees excluded)"
+    return title
+
+
+def make_quadtree_figure(data: Dict[str, List], title: str | None = None):
     from bokeh.models import ColumnDataSource
     from bokeh.palettes import Viridis256
     from bokeh.transform import linear_cmap
@@ -180,10 +208,10 @@ def make_quadtree_figure(data: Dict[str, List]):
     low = min(data["amount"]) if data["amount"] else 0
     high = max(data["amount"]) if data["amount"] else 1
     color_map = linear_cmap("amount", Viridis256, low, high)
-    return _build_quadtree_plot(source, color_map)
+    return _build_quadtree_plot(source, color_map, title)
 
 
-def _build_quadtree_plot(source, color_map):
+def _build_quadtree_plot(source, color_map, title: str | None = None):
     from bokeh.plotting import figure
 
     p = figure(
@@ -194,7 +222,7 @@ def _build_quadtree_plot(source, color_map):
         toolbar_location="above",
         tools="pan,wheel_zoom,reset,save",
         outline_line_color=None,
-        title=None,
+        title=title,
     )
     _add_rectangles(p, source, color_map)
     _add_labels(p, source)
@@ -245,6 +273,7 @@ def write_payee_quadtree_html(entries: List[CheckEntry], out_path: Path, drop: i
     from bokeh.plotting import output_file, save
 
     data = build_payee_quadtree_data(entries, drop=drop)
-    plot = make_quadtree_figure(data)
-    output_file(out_path, title="Payees by Dollar Amount")
+    title = build_payee_quadtree_title(entries, data, drop=drop)
+    plot = make_quadtree_figure(data, title=title)
+    output_file(out_path, title=title)
     save(plot)

--- a/tests/test_quadtree_output.py
+++ b/tests/test_quadtree_output.py
@@ -2,7 +2,7 @@ import unittest
 from decimal import Decimal
 
 from check_register.models import CheckEntry
-from check_register.outputs import build_payee_quadtree_data
+from check_register.outputs import build_payee_quadtree_data, build_payee_quadtree_title
 
 
 class TestPayeeQuadtreeData(unittest.TestCase):
@@ -37,6 +37,30 @@ class TestPayeeQuadtreeData(unittest.TestCase):
         data = build_payee_quadtree_data(entries, drop=1)
         self.assertNotIn("CalPERS", data["payee"])
         self.assertCountEqual(sorted(data["payee"]), ["Alpha", "Beta"])
+
+    def test_title_with_drop(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "A", "a", Decimal("500.00"), False),
+            CheckEntry(6, 2025, "check", "2", "06/02/2025", "Open", "Accounts Payable", "B", "b", Decimal("450.00"), False),
+            CheckEntry(6, 2025, "check", "3", "06/03/2025", "Open", "Accounts Payable", "C", "c", Decimal("100.00"), False),
+            CheckEntry(6, 2025, "check", "4", "06/04/2025", "Open", "Accounts Payable", "D", "d", Decimal("90.00"), False),
+            CheckEntry(6, 2025, "check", "5", "06/05/2025", "Open", "Accounts Payable", "E", "e", Decimal("10.00"), False),
+        ]
+        data = build_payee_quadtree_data(entries, drop=3)
+        title = build_payee_quadtree_title(entries, data, drop=3)
+        self.assertEqual(
+            title,
+            "June 2025 Checks/EFT Report: $1,150.00 ($100.00 shown, top 3 payees excluded)",
+        )
+
+    def test_title_no_drop_multi_month(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "Alpha", "a", Decimal("50.00"), False),
+            CheckEntry(7, 2025, "check", "2", "07/01/2025", "Open", "Accounts Payable", "Beta", "b", Decimal("75.00"), False),
+        ]
+        data = build_payee_quadtree_data(entries)
+        title = build_payee_quadtree_title(entries, data)
+        self.assertEqual(title, "June–July 2025 Checks/EFT Report: $125.00")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- build payee quadtree titles summarizing date range, totals and dropped payee info
- pass title into Bokeh figure and HTML output
- test quadtree titles for dropped and multi-month cases

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68ae1cfd22908322a47a911e42f53551