### PR TITLE
Show single checks in quadtree and format amounts

### DIFF
--- a/check_register/outputs.py
+++ b/check_register/outputs.py
@@ -133,7 +133,7 @@ def assemble_quadtree_data(rects: List[Dict[str, float]], payees: Dict[str, List
         info = payees[payee]
         descs = sorted({e.description for e in info if e.description})
         nums = [(e.number, e.amount) for e in info]
-        checks = ", ".join(f"{n}: ${a:.2f}" for n, a in nums) if len({n for n, _ in nums}) > 1 else ""
+        checks = ", ".join(f"{n}: ${a:,.2f}" for n, a in nums)
         w, h = r["w"], r["h"]
         data["cx"].append(r["x"] + w / 2)
         data["cy"].append(r["y"] + h / 2)

--- a/tests/test_quadtree_output.py
+++ b/tests/test_quadtree_output.py
@@ -10,7 +10,7 @@ class TestPayeeQuadtreeData(unittest.TestCase):
         entries = [
             CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "Alpha", "foo", Decimal("100.00"), False),
             CheckEntry(6, 2025, "check", "2", "06/02/2025", "Open", "Accounts Payable", "Alpha", "bar", Decimal("50.00"), False),
-            CheckEntry(6, 2025, "check", "3", "06/03/2025", "Open", "Accounts Payable", "Beta", "baz", Decimal("10.00"), False),
+            CheckEntry(6, 2025, "check", "3", "06/03/2025", "Open", "Accounts Payable", "Beta", "baz", Decimal("1000.00"), False),
         ]
         data = build_payee_quadtree_data(entries)
         alpha_idx = data["payee"].index("Alpha")
@@ -19,7 +19,7 @@ class TestPayeeQuadtreeData(unittest.TestCase):
         self.assertIn("1: $100.00", data["checks"][alpha_idx])
         self.assertIn("2: $50.00", data["checks"][alpha_idx])
         beta_idx = data["payee"].index("Beta")
-        self.assertEqual("", data["checks"][beta_idx])
+        self.assertIn("3: $1,000.00", data["checks"][beta_idx])
 
     def test_label_fits_single_payee(self):
         entries = [


### PR DESCRIPTION
## Summary
- Always list check numbers in the quadtree, even for single-check payees
- Display check amounts with thousands separators
- Adapt tests to expect single-check display and formatted amounts

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68ae1d592dc48322a26d4117accf642e