### PR TITLE
Add deduped monthly totals option

### DIFF
--- a/check_register/__init__.py
+++ b/check_register/__init__.py
@@ -6,4 +6,4 @@ from .outputs import (
     write_payee_quadtree_html,
     write_chunks,
 )
-from .stats import sanity, month_rollups
+from .stats import sanity, month_rollups, month_totals

--- a/check_register/stats.py
+++ b/check_register/stats.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Dict, List, Tuple
+from datetime import datetime
+from typing import Dict, List, Set, Tuple
 
 from .models import CheckEntry
 
@@ -32,4 +33,27 @@ def month_rollups(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Dict[str, 
             elif e.ap_type == "eft":
                 out[key]["efts"] += e.amount
             out[key]["grand"] += e.amount
+    return out
+
+
+def month_totals(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Decimal]:
+    """Return non-void monthly totals, deduplicating overlapping registers.
+
+    Totals are grouped by the check's own date rather than the PDF section
+    headers.  This prevents double counting when a check appears in multiple
+    overlapping registers.
+    """
+
+    out: Dict[Tuple[int, int], Decimal] = {}
+    seen: Set[Tuple[str, str, str, Decimal]] = set()
+    for e in entries:
+        if e.voided:
+            continue
+        key = (e.ap_type, e.number, e.date, e.amount)
+        if key in seen:
+            continue
+        seen.add(key)
+        dt = datetime.strptime(e.date, "%m/%d/%Y")
+        month_key = (dt.month, dt.year)
+        out[month_key] = out.get(month_key, Decimal("0.00")) + e.amount
     return out

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -10,6 +10,7 @@ import sys
 from check_register import (
     CheckRegisterParser,
     month_rollups,
+    month_totals,
     sanity,
     write_csv,
     write_json,
@@ -34,6 +35,7 @@ def main() -> None:
     ap.add_argument("--drop", type=int, default=0, help="Drop the N largest payees from the quadtree")
     ap.add_argument("--drop-voided", action="store_true", help="Exclude voided/voided-reissued rows from output")
     ap.add_argument("--print-rollups", action="store_true", help="Print per-month rollups after parsing")
+    ap.add_argument("--totals", action="store_true", help="Print total spent per month")
     ap.add_argument(
         "--chunks-json", nargs="?", type=Path, const=True, default=None,
         help="Output raw row chunks JSON for tests",
@@ -52,6 +54,7 @@ def main() -> None:
         or args.json is not None
         or args.html is not None
         or args.print_rollups
+        or args.totals
         or args.pdf_out is True
         or args.chunks_json is True
     )
@@ -91,7 +94,7 @@ def main() -> None:
         if args.html:
             write_payee_quadtree_html(entries, args.html, drop=args.drop)
 
-        if args.csv or args.json or args.html or args.print_rollups:
+        if args.csv or args.json or args.html or args.print_rollups or args.totals:
             stats = sanity(entries)
             print(
                 f"Rows: {stats['count']}  (checks={stats['by_type'].get('check', 0)}, "
@@ -115,6 +118,14 @@ def main() -> None:
                             f"  {m:02d}/{y}: checks=${sums['checks']:.2f}  "
                             f"efts=${sums['efts']:.2f}  grand=${sums['grand']:.2f}"
                         )
+            if args.totals:
+                totals = month_totals(entries)
+                if not totals:
+                    print("No month totals to display.")
+                else:
+                    print("\nPer-month totals (non-void, deduped):")
+                    for (m, y), total in sorted(totals.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+                        print(f"  {m:02d}/{y}: ${total:.2f}")
 
     if need_chunks and chunks is not None:
         if args.chunks_json is True:

--- a/tests/test_month_totals_2025_06_07.py
+++ b/tests/test_month_totals_2025_06_07.py
@@ -1,0 +1,44 @@
+import json
+import unittest
+from collections import defaultdict
+from decimal import Decimal
+
+from project_paths import ARTIFACT_CHUNKS_DIR
+
+from check_register.parser import CheckRegisterParser
+from check_register.models import RowChunk
+from check_register.stats import month_totals
+
+
+class TestMonthTotalsJune2025(unittest.TestCase):
+    def test_month_totals_dedup(self):
+        chunk_path = ARTIFACT_CHUNKS_DIR / "2025-06-07.json"
+        with chunk_path.open() as f:
+            chunks = [RowChunk(**c) for c in json.load(f)]
+        parser = CheckRegisterParser(chunk_path)
+        entries = parser.parse_chunks(chunks)
+
+        # 6/30/2025 appears in both the June and July registers; ensure
+        # duplicates are only counted once and attributed to June.
+        seen_sections = defaultdict(set)
+        for e in entries:
+            key = (e.ap_type, e.number, e.date, e.amount)
+            seen_sections[key].add(e.section_month)
+
+        dup_keys = [k for k, months in seen_sections.items() if len(months) > 1]
+        self.assertEqual(len(dup_keys), 63)
+        self.assertTrue(all(k[0] == "check" and k[2] == "06/30/2025" for k in dup_keys))
+        self.assertTrue(all(seen_sections[k] == {6, 7} for k in dup_keys))
+
+        eft_630 = [e for e in entries if e.ap_type == "eft" and e.date == "06/30/2025"]
+        self.assertEqual(len(eft_630), 17)
+        self.assertEqual({e.section_month for e in eft_630}, {6})
+
+        totals = month_totals(entries)
+        self.assertEqual(totals[(6, 2025)], Decimal("4569023.17"))
+        self.assertEqual(totals[(7, 2025)], Decimal("14296239.84"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_register_stats.py
+++ b/tests/test_register_stats.py
@@ -28,14 +28,20 @@ class TestRegisterStats(unittest.TestCase):
         self.assertEqual(roll[(7, 2025)]["grand"], Decimal("0.00"))
 
     def test_month_totals_dedup(self):
-        dup_entries = [
-            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "A", "", Decimal("100.00"), False),
-            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "A", "", Decimal("100.00"), False),
-            CheckEntry(7, 2025, "eft", "2", "07/02/2025", "Open", "Accounts Payable", "B", "", Decimal("50.00"), False),
-            CheckEntry(7, 2025, "eft", "2", "07/02/2025", "Open", "Accounts Payable", "B", "", Decimal("50.00"), False),
-            CheckEntry(7, 2025, "check", "3", "07/03/2025", "Open", "Accounts Payable", "C", "", Decimal("75.00"), False),
-            CheckEntry(7, 2025, "check", "3", "07/03/2025", "Open", "Accounts Payable", "C", "", Decimal("75.00"), True),
+        """Checks on 06/30 appear in two section months but should count once."""
+        entries = [
+            # Unique June check
+            CheckEntry(6, 2025, "check", "1", "06/29/2025", "Open", "Accounts Payable", "A", "", Decimal("50.00"), False),
+            # June 30 checks duplicated in the July register
+            CheckEntry(6, 2025, "check", "2", "06/30/2025", "Open", "Accounts Payable", "B", "", Decimal("75.00"), False),
+            CheckEntry(7, 2025, "check", "2", "06/30/2025", "Open", "Accounts Payable", "B", "", Decimal("75.00"), False),
+            CheckEntry(6, 2025, "check", "3", "06/30/2025", "Open", "Accounts Payable", "C", "", Decimal("125.00"), False),
+            CheckEntry(7, 2025, "check", "3", "06/30/2025", "Open", "Accounts Payable", "C", "", Decimal("125.00"), False),
+            # June-only EFT on 06/30
+            CheckEntry(6, 2025, "eft", "4", "06/30/2025", "Open", "Accounts Payable", "D", "", Decimal("20.00"), False),
+            # Genuine July check
+            CheckEntry(7, 2025, "check", "5", "07/01/2025", "Open", "Accounts Payable", "E", "", Decimal("10.00"), False),
         ]
-        totals = month_totals(dup_entries)
-        self.assertEqual(totals[(6, 2025)], Decimal("100.00"))
-        self.assertEqual(totals[(7, 2025)], Decimal("125.00"))
+        totals = month_totals(entries)
+        self.assertEqual(totals[(6, 2025)], Decimal("270.00"))
+        self.assertEqual(totals[(7, 2025)], Decimal("10.00"))

--- a/tests/test_register_stats.py
+++ b/tests/test_register_stats.py
@@ -1,7 +1,7 @@
 import unittest
 from decimal import Decimal
 
-from check_register import CheckEntry, month_rollups, sanity
+from check_register import CheckEntry, month_rollups, month_totals, sanity
 
 
 class TestRegisterStats(unittest.TestCase):
@@ -26,3 +26,16 @@ class TestRegisterStats(unittest.TestCase):
         self.assertEqual(roll[(6, 2025)]["efts"], Decimal("200.00"))
         self.assertEqual(roll[(6, 2025)]["grand"], Decimal("300.00"))
         self.assertEqual(roll[(7, 2025)]["grand"], Decimal("0.00"))
+
+    def test_month_totals_dedup(self):
+        dup_entries = [
+            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "A", "", Decimal("100.00"), False),
+            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "A", "", Decimal("100.00"), False),
+            CheckEntry(7, 2025, "eft", "2", "07/02/2025", "Open", "Accounts Payable", "B", "", Decimal("50.00"), False),
+            CheckEntry(7, 2025, "eft", "2", "07/02/2025", "Open", "Accounts Payable", "B", "", Decimal("50.00"), False),
+            CheckEntry(7, 2025, "check", "3", "07/03/2025", "Open", "Accounts Payable", "C", "", Decimal("75.00"), False),
+            CheckEntry(7, 2025, "check", "3", "07/03/2025", "Open", "Accounts Payable", "C", "", Decimal("75.00"), True),
+        ]
+        totals = month_totals(dup_entries)
+        self.assertEqual(totals[(6, 2025)], Decimal("100.00"))
+        self.assertEqual(totals[(7, 2025)], Decimal("125.00"))


### PR DESCRIPTION
## Summary
- add `month_totals` helper to deduplicate overlapping registers and compute monthly totals
- support a new `--totals` CLI flag to show per-month totals
- assert 6/30/2025 duplicates in the 2025-06-07 register and ensure totals credit them to June

## Testing
- `python -m unittest discover -s tests`
- `./check_register_parser.py data/artifacts/pdfs/2025-06-07-register.pdf --totals`


------
https://chatgpt.com/codex/tasks/task_e_68ae1e16a21c8322b4a0a743d551eac3