### PR TITLE
Deduplicate totals by check number and add thousands separators

### DIFF
--- a/check_register/stats.py
+++ b/check_register/stats.py
@@ -8,14 +8,25 @@ from .models import CheckEntry
 
 
 def sanity(entries: List[CheckEntry]) -> Dict[str, object]:
-    """Basic stats by type, and total excluding voided rows."""
+    """Basic stats by type, and total excluding voided rows.
+
+    The non-void total deduplicates by check number to avoid double
+    counting across overlapping registers.
+    """
+
     cnt = len(entries)
     by_type = {"check": 0, "eft": 0}
     total = Decimal("0.00")
+    seen: Set[Tuple[str, str]] = set()
     for e in entries:
         by_type[e.ap_type] = by_type.get(e.ap_type, 0) + 1
-        if not e.voided:
-            total += e.amount
+        if e.voided:
+            continue
+        key = (e.ap_type, e.number)
+        if key in seen:
+            continue
+        seen.add(key)
+        total += e.amount
     return {"count": cnt, "by_type": by_type, "total_nonvoid": total}
 
 
@@ -37,19 +48,19 @@ def month_rollups(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Dict[str, 
 
 
 def month_totals(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Decimal]:
-    """Return non-void monthly totals, deduplicating overlapping registers.
+    """Return non-void monthly totals, deduplicating by check number.
 
     Totals are grouped by the check's own date rather than the PDF section
-    headers.  This prevents double counting when a check appears in multiple
+    headers. This prevents double counting when a check appears in multiple
     overlapping registers.
     """
 
     out: Dict[Tuple[int, int], Decimal] = {}
-    seen: Set[Tuple[str, str, str, Decimal]] = set()
+    seen: Set[Tuple[str, str]] = set()
     for e in entries:
         if e.voided:
             continue
-        key = (e.ap_type, e.number, e.date, e.amount)
+        key = (e.ap_type, e.number)
         if key in seen:
             continue
         seen.add(key)

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -100,7 +100,7 @@ def main() -> None:
                 f"Rows: {stats['count']}  (checks={stats['by_type'].get('check', 0)}, "
                 f"efts={stats['by_type'].get('eft', 0)})"
             )
-            print(f"Total (non-void): ${stats['total_nonvoid']:.2f}")
+            print(f"Total (non-void): ${stats['total_nonvoid']:,.2f}")
             if args.csv:
                 print(f"CSV: {args.csv}")
             if args.json:
@@ -115,8 +115,8 @@ def main() -> None:
                     print("\nPer-month rollups (non-void totals):")
                     for (m, y), sums in sorted(roll.items(), key=lambda kv: (kv[0][1], kv[0][0])):
                         print(
-                            f"  {m:02d}/{y}: checks=${sums['checks']:.2f}  "
-                            f"efts=${sums['efts']:.2f}  grand=${sums['grand']:.2f}"
+                            f"  {m:02d}/{y}: checks=${sums['checks']:,.2f}  "
+                            f"efts=${sums['efts']:,.2f}  grand=${sums['grand']:,.2f}"
                         )
             if args.totals:
                 totals = month_totals(entries)
@@ -125,7 +125,7 @@ def main() -> None:
                 else:
                     print("\nPer-month totals (non-void, deduped):")
                     for (m, y), total in sorted(totals.items(), key=lambda kv: (kv[0][1], kv[0][0])):
-                        print(f"  {m:02d}/{y}: ${total:.2f}")
+                        print(f"  {m:02d}/{y}: ${total:,.2f}")
 
     if need_chunks and chunks is not None:
         if args.chunks_json is True:


### PR DESCRIPTION
## Summary
- Deduplicate non-void totals by check number to prevent double counting
- Display totals with thousands separators in CLI output

## Testing
- `python -m unittest discover -s tests`
- `./check_register_parser.py data/originals/2025/Agenda\ Packet\ (8.19.2025).pdf --html /tmp/test.html --drop 5 --totals --csv /tmp/test.csv --pdf /tmp/test.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68ae52c42740832282a9e449dcda6497