### PR TITLE
Dedup totals by check number and add thousands separators

### DIFF
--- a/check_register/stats.py
+++ b/check_register/stats.py
@@ -12,10 +12,12 @@ def sanity(entries: List[CheckEntry]) -> Dict[str, object]:
     cnt = len(entries)
     by_type = {"check": 0, "eft": 0}
     total = Decimal("0.00")
+    seen_numbers: Set[str] = set()
     for e in entries:
         by_type[e.ap_type] = by_type.get(e.ap_type, 0) + 1
-        if not e.voided:
+        if not e.voided and e.number not in seen_numbers:
             total += e.amount
+            seen_numbers.add(e.number)
     return {"count": cnt, "by_type": by_type, "total_nonvoid": total}
 
 
@@ -37,7 +39,7 @@ def month_rollups(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Dict[str, 
 
 
 def month_totals(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Decimal]:
-    """Return non-void monthly totals, deduplicating overlapping registers.
+    """Return non-void monthly totals, deduplicating overlapping registers by check number.
 
     Totals are grouped by the check's own date rather than the PDF section
     headers.  This prevents double counting when a check appears in multiple
@@ -45,14 +47,11 @@ def month_totals(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Decimal]:
     """
 
     out: Dict[Tuple[int, int], Decimal] = {}
-    seen: Set[Tuple[str, str, str, Decimal]] = set()
+    seen_numbers: Set[str] = set()
     for e in entries:
-        if e.voided:
+        if e.voided or e.number in seen_numbers:
             continue
-        key = (e.ap_type, e.number, e.date, e.amount)
-        if key in seen:
-            continue
-        seen.add(key)
+        seen_numbers.add(e.number)
         dt = datetime.strptime(e.date, "%m/%d/%Y")
         month_key = (dt.month, dt.year)
         out[month_key] = out.get(month_key, Decimal("0.00")) + e.amount

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -100,7 +100,7 @@ def main() -> None:
                 f"Rows: {stats['count']}  (checks={stats['by_type'].get('check', 0)}, "
                 f"efts={stats['by_type'].get('eft', 0)})"
             )
-            print(f"Total (non-void): ${stats['total_nonvoid']:.2f}")
+            print(f"Total (non-void): ${stats['total_nonvoid']:,.2f}")
             if args.csv:
                 print(f"CSV: {args.csv}")
             if args.json:
@@ -115,8 +115,8 @@ def main() -> None:
                     print("\nPer-month rollups (non-void totals):")
                     for (m, y), sums in sorted(roll.items(), key=lambda kv: (kv[0][1], kv[0][0])):
                         print(
-                            f"  {m:02d}/{y}: checks=${sums['checks']:.2f}  "
-                            f"efts=${sums['efts']:.2f}  grand=${sums['grand']:.2f}"
+                            f"  {m:02d}/{y}: checks=${sums['checks']:,.2f}  "
+                            f"efts=${sums['efts']:,.2f}  grand=${sums['grand']:,.2f}"
                         )
             if args.totals:
                 totals = month_totals(entries)
@@ -125,7 +125,7 @@ def main() -> None:
                 else:
                     print("\nPer-month totals (non-void, deduped):")
                     for (m, y), total in sorted(totals.items(), key=lambda kv: (kv[0][1], kv[0][0])):
-                        print(f"  {m:02d}/{y}: ${total:.2f}")
+                        print(f"  {m:02d}/{y}: ${total:,.2f}")
 
     if need_chunks and chunks is not None:
         if args.chunks_json is True:

--- a/tests/test_register_stats.py
+++ b/tests/test_register_stats.py
@@ -18,6 +18,15 @@ class TestRegisterStats(unittest.TestCase):
         self.assertEqual(stats["by_type"], {"check": 2, "eft": 1})
         self.assertEqual(stats["total_nonvoid"], Decimal("300.00"))
 
+
+    def test_sanity_dedup_by_number(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "A", "", Decimal("100.00"), False),
+            CheckEntry(7, 2025, "check", "1", "07/01/2025", "Open", "Accounts Payable", "A", "", Decimal("100.00"), False),
+        ]
+        stats = sanity(entries)
+        self.assertEqual(stats["total_nonvoid"], Decimal("100.00"))
+
     def test_month_rollups(self):
         roll = month_rollups(self.entries)
         self.assertIn((6, 2025), roll)


### PR DESCRIPTION
## Summary
- Avoid double-counting by tracking seen check numbers when computing overall and monthly totals
- Display overall, rollup, and monthly totals with thousands separators for readability
- Add a regression test confirming total de-duplication by check number

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'pypdfium2', pdfplumber)*
- `./scripts/codex_setup.sh` *(fails: /usr/bin/env: 'bash': No such file or directory)*

## Notes
- Squash commit message: Dedup totals by check number and add thousands separators

------
https://chatgpt.com/codex/tasks/task_e_68ae52c42740832282a9e449dcda6497