### PR TITLE
Deduplicate quadtree totals

### DIFF
--- a/check_register/outputs.py
+++ b/check_register/outputs.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from .models import CheckEntry, RowChunk
+from .stats import dedupe_by_number
 
 
 def write_csv(entries: List[CheckEntry], out_path: Path) -> None:
@@ -53,8 +54,6 @@ def write_chunks(chunks: List[RowChunk], out_path: Path) -> None:
 def group_payees(entries: List[CheckEntry]) -> Dict[str, List[CheckEntry]]:
     payees: Dict[str, List[CheckEntry]] = {}
     for e in entries:
-        if e.voided:
-            continue
         payees.setdefault(e.payee, []).append(e)
     return payees
 
@@ -161,6 +160,9 @@ def build_payee_quadtree_data(entries: List[CheckEntry], drop: int = 0) -> Dict[
         drop: Number of highest-dollar payees to exclude from the tree.
     """
 
+    # Drop voided rows and deduplicate by check number so repeated checks
+    # from overlapping registers don't inflate totals.
+    entries = dedupe_by_number([e for e in entries if not e.voided])
     payees = group_payees(entries)
     items = payee_totals(payees)
     if drop > 0:
@@ -174,6 +176,8 @@ def build_payee_quadtree_data(entries: List[CheckEntry], drop: int = 0) -> Dict[
 
 
 def build_payee_quadtree_title(entries: List[CheckEntry], data: Dict[str, List], drop: int = 0) -> str:
+    # Use deduplicated non-void entries to determine period and totals.
+    entries = dedupe_by_number([e for e in entries if not e.voided])
     months = sorted({(e.section_year, e.section_month) for e in entries})
     if months:
         sy, sm = months[0]
@@ -187,12 +191,9 @@ def build_payee_quadtree_title(entries: List[CheckEntry], data: Dict[str, List],
             period = f"{start}–{month_name[em]} {ey}"
     else:
         period = "Unknown period"
-    grand_total = sum((e.amount for e in entries if not e.voided), Decimal("0.00"))
+    grand_total = sum((e.amount for e in entries), Decimal("0.00"))
     shown_payees = set(data["payee"])
-    shown_total = sum(
-        (e.amount for e in entries if not e.voided and e.payee in shown_payees),
-        Decimal("0.00"),
-    )
+    shown_total = sum((e.amount for e in entries if e.payee in shown_payees), Decimal("0.00"))
     title = f"{period} Checks/EFT Report: ${grand_total:,.2f}"
     if drop > 0:
         title += f" (${shown_total:,.2f} shown, top {drop} payees excluded)"

--- a/check_register/stats.py
+++ b/check_register/stats.py
@@ -2,22 +2,31 @@ from __future__ import annotations
 
 from decimal import Decimal
 from datetime import datetime
-from typing import Dict, List, Set, Tuple
+from typing import Dict, Iterable, List, Set, Tuple
 
 from .models import CheckEntry
+
+
+def dedupe_by_number(entries: Iterable[CheckEntry]) -> List[CheckEntry]:
+    """Return the first entry for each unique check number."""
+    seen: Set[str] = set()
+    out: List[CheckEntry] = []
+    for e in entries:
+        if e.number in seen:
+            continue
+        seen.add(e.number)
+        out.append(e)
+    return out
 
 
 def sanity(entries: List[CheckEntry]) -> Dict[str, object]:
     """Basic stats by type, and total excluding voided rows."""
     cnt = len(entries)
     by_type = {"check": 0, "eft": 0}
-    total = Decimal("0.00")
-    seen_numbers: Set[str] = set()
     for e in entries:
         by_type[e.ap_type] = by_type.get(e.ap_type, 0) + 1
-        if not e.voided and e.number not in seen_numbers:
-            total += e.amount
-            seen_numbers.add(e.number)
+    nonvoid = [e for e in entries if not e.voided]
+    total = sum(e.amount for e in dedupe_by_number(nonvoid))
     return {"count": cnt, "by_type": by_type, "total_nonvoid": total}
 
 
@@ -47,11 +56,8 @@ def month_totals(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Decimal]:
     """
 
     out: Dict[Tuple[int, int], Decimal] = {}
-    seen_numbers: Set[str] = set()
-    for e in entries:
-        if e.voided or e.number in seen_numbers:
-            continue
-        seen_numbers.add(e.number)
+    nonvoid = [e for e in entries if not e.voided]
+    for e in dedupe_by_number(nonvoid):
         dt = datetime.strptime(e.date, "%m/%d/%Y")
         month_key = (dt.month, dt.year)
         out[month_key] = out.get(month_key, Decimal("0.00")) + e.amount

--- a/tests/test_quadtree_output.py
+++ b/tests/test_quadtree_output.py
@@ -62,6 +62,18 @@ class TestPayeeQuadtreeData(unittest.TestCase):
         title = build_payee_quadtree_title(entries, data)
         self.assertEqual(title, "June–July 2025 Checks/EFT Report: $125.00")
 
+    def test_dedup_duplicate_checks(self):
+        """Ensure duplicate check numbers across months count once."""
+        entries = [
+            CheckEntry(6, 2025, "check", "1", "06/15/2025", "Open", "Accounts Payable", "Alpha", "a", Decimal("100.00"), False),
+            # Duplicate of the same check in a later register
+            CheckEntry(7, 2025, "check", "1", "06/15/2025", "Open", "Accounts Payable", "Alpha", "a", Decimal("100.00"), False),
+        ]
+        data = build_payee_quadtree_data(entries)
+        self.assertEqual(data["amount"][0], 100.0)
+        title = build_payee_quadtree_title(entries, data)
+        self.assertEqual(title, "June 2025 Checks/EFT Report: $100.00")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- centralize check-number deduplication with `dedupe_by_number`
- ensure payee quadtree uses deduped entries for data and title
- add regression test covering duplicate checks across months

## Testing
- `python -m unittest discover -s tests`
- `./check_register_parser.py data/originals/2025/Agenda\ Packet\ \(8.19.2025\).pdf --html --drop 6 --totals --csv --pdf`

------
https://chatgpt.com/codex/tasks/task_e_68ae8b66543c832294c23cedfc3a8c58