### PR TITLE
Simplify artifact regeneration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,7 @@ Accuracy tests such as `tests/test_june_2025_payees.py`, `tests/test_jul_aug_202
 If parser changes might affect output, regenerate sample artifacts:
 
 ```bash
-for pdf in data/originals/2025/*.pdf; do
-  ./scripts/build_register_archive.sh "$pdf"
-done
+./scripts/build_register_archive.sh
 ```
 
 ALWAYS regenerate artifacts in separate pull request from the code changes that triggered them. Never mix code code changes and data artifacts in a pull request.

--- a/scripts/build_register_archive.sh
+++ b/scripts/build_register_archive.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Generate register artifacts for a single agenda packet PDF using the
-# check_register_parser CLI. Artifacts are stored under data/artifacts by
-# default.
+# Generate register artifacts for all agenda packet PDFs under the originals
+# directory using the check_register_parser CLI. Artifacts are stored under
+# data/artifacts by default.
 
-if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <agenda-packet.pdf> [archive-dir]" >&2
+if [[ $# -gt 2 ]]; then
+  echo "Usage: $0 [originals-dir] [archive-dir]" >&2
   exit 1
 fi
 
-packet_pdf="$1"
-archive_dir="${2:-$(dirname "$0")/../data/artifacts}"
-
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+originals_dir="${1:-$repo_root/data/originals}"
+archive_dir="${2:-$repo_root/data/artifacts}"
 parser="$repo_root/check_register_parser.py"
 
 pdf_dir="$archive_dir/pdfs"
@@ -21,19 +20,21 @@ csv_dir="$archive_dir/csv"
 chunk_dir="$archive_dir/chunks"
 mkdir -p "$pdf_dir" "$csv_dir" "$chunk_dir"
 
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+find "$originals_dir" -type f -name '*.pdf' -print0 | sort -z | \
+  while IFS= read -r -d '' packet_pdf; do
+    tmpdir=$(mktemp -d)
+    (
+      cd "$tmpdir"
+      "$parser" "$packet_pdf" --pdf --csv --chunks-json
+    )
 
-(
-  cd "$tmpdir"
-  "$parser" "$packet_pdf" --pdf --csv --chunks-json
-)
+    prefix=$(cd "$tmpdir" && ls *.csv)
+    prefix="${prefix%.csv}"
 
-prefix=$(cd "$tmpdir" && ls *.csv)
-prefix="${prefix%.csv}"
+    mv "$tmpdir/${prefix}-register.pdf" "$pdf_dir/"
+    mv "$tmpdir/${prefix}.csv" "$csv_dir/"
+    mv "$tmpdir/${prefix}-chunks.json" "$chunk_dir/"
+    rm -rf "$tmpdir"
 
-mv "$tmpdir/${prefix}-register.pdf" "$pdf_dir/"
-mv "$tmpdir/${prefix}.csv" "$csv_dir/"
-mv "$tmpdir/${prefix}-chunks.json" "$chunk_dir/"
-
-echo "Archive updated: $pdf_dir/${prefix}-register.pdf"
+    echo "Archive updated: $pdf_dir/${prefix}-register.pdf"
+  done


### PR DESCRIPTION
## Summary
- Let `build_register_archive.sh` regenerate artifacts for all PDFs in `data/originals`
- Update contributor instructions to call the script once instead of looping

## Testing
- `python -m unittest discover -s tests`

---
Suggested squash commit message:
Simplify artifact regeneration


------
https://chatgpt.com/codex/tasks/task_e_68ae9344852c8322bf20553ff50af0d6