### PR TITLE
Archive quadtree HTML outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ Thumbs.db
 *.csv
 !data/artifacts/**/*.csv
 
+# Generated quadtree HTML (keep archived outputs)
+*.html
+!data/artifacts/**/*.html
+
 # Virtual environment
 codex-wheel-build/
 venv/

--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 Utility for extracting the "Monthly Disbursement and Check Register Report"
 from City of El Cerrito city council agenda packet PDFs. The project targets
 offline parsing: source PDFs from [www.elcerrito.gov](https://www.elcerrito.gov)
-reside under `data/originals/`, and parser artifacts used in tests live under
-`data/artifacts/`. Unit tests enforce payee and description extraction fidelity.
+reside under `data/originals/`, and parser artifacts (CSV, chunk JSON, payee
+HTML, and register PDFs) used in tests live under `data/artifacts/`. Unit tests
+enforce payee and description extraction fidelity.
 The script `check_register_parser.py` reads a packet PDF and emits a CSV file
 containing one row per check along with a couple of simple aggregates. It can
 also produce an HTML quadtree showing payees sized by total dollar amount and
 optionally extracts the check register pages into a standalone PDF.
 
 Sample agenda packets live under ``data/originals/YYYY/`` with derived
-artifacts (CSV, chunk JSON and register PDFs) in ``data/artifacts/``.
+artifacts (CSV, chunk JSON, payee HTML and register PDFs) in ``data/artifacts/``.
 
 ## Usage
 

--- a/scripts/build_register_archive.sh
+++ b/scripts/build_register_archive.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Generate register artifacts for all agenda packet PDFs under the originals
 # directory using the check_register_parser CLI. Artifacts are stored under
-# data/artifacts by default.
+# data/artifacts by default. Outputs include register PDFs, CSVs, chunk JSON,
+# and payee quadtree HTML.
 
 if [[ $# -gt 2 ]]; then
   echo "Usage: $0 [originals-dir] [archive-dir]" >&2
@@ -18,14 +19,15 @@ parser="$repo_root/check_register_parser.py"
 pdf_dir="$archive_dir/pdfs"
 csv_dir="$archive_dir/csv"
 chunk_dir="$archive_dir/chunks"
-mkdir -p "$pdf_dir" "$csv_dir" "$chunk_dir"
+html_dir="$archive_dir/html"
+mkdir -p "$pdf_dir" "$csv_dir" "$chunk_dir" "$html_dir"
 
 find "$originals_dir" -type f -name '*.pdf' -print0 | sort -z | \
   while IFS= read -r -d '' packet_pdf; do
     tmpdir=$(mktemp -d)
     (
       cd "$tmpdir"
-      "$parser" "$packet_pdf" --pdf --csv --chunks-json
+      "$parser" "$packet_pdf" --pdf --csv --chunks-json --html
     )
 
     prefix=$(cd "$tmpdir" && ls *.csv)
@@ -34,6 +36,7 @@ find "$originals_dir" -type f -name '*.pdf' -print0 | sort -z | \
     mv "$tmpdir/${prefix}-register.pdf" "$pdf_dir/"
     mv "$tmpdir/${prefix}.csv" "$csv_dir/"
     mv "$tmpdir/${prefix}-chunks.json" "$chunk_dir/"
+    mv "$tmpdir/${prefix}-payees.html" "$html_dir/"
     rm -rf "$tmpdir"
 
     echo "Archive updated: $pdf_dir/${prefix}-register.pdf"


### PR DESCRIPTION
## Summary
- include payee quadtree HTML in build_register_archive.sh outputs
- ignore loose HTML files outside archived artifacts
- document payee HTML in data/artifacts layout

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68ae975e3f3c8322b69bda7d01c1eaf8