### PR TITLE
Refactor CLI helper flow and add tests

### DIFF
--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
 import sys
 
@@ -24,9 +25,18 @@ from check_register.page_extractor import (
 )
 
 
-def main() -> None:
+@dataclass
+class OutputPaths:
+    csv: Path | None = None
+    json: Path | None = None
+    html: Path | None = None
+    chunks_json: Path | None = None
+    pdf: Path | None = None
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     ap = argparse.ArgumentParser(
-        description="Parse El Cerrito Agenda Packet check/EFT registers into CSV/JSON or extract pages to PDF."
+        description="Parse El Cerrito Agenda Packet check/EFT registers into CSV/JSON or extract pages to PDF.",
     )
     ap.add_argument("pdf", type=Path, help="Agenda Packet PDF path")
     ap.add_argument("--csv", nargs="?", type=Path, const=True, default=None, help="Output CSV path")
@@ -37,17 +47,84 @@ def main() -> None:
     ap.add_argument("--print-rollups", action="store_true", help="Print per-month rollups after parsing")
     ap.add_argument("--totals", action="store_true", help="Print total spent per month")
     ap.add_argument(
-        "--chunks-json", nargs="?", type=Path, const=True, default=None,
-        help="Output raw row chunks JSON for tests",
+        "--chunks-json", nargs="?", type=Path, const=True, default=None, help="Output raw row chunks JSON for tests",
     )
     ap.add_argument(
-        "--pdf", nargs="?", type=Path, const=True, dest="pdf_out", default=None,
-        help="Extract check register pages to a PDF",
+        "--pdf", nargs="?", type=Path, const=True, dest="pdf_out", default=None, help="Extract check register pages to a PDF",
     )
-    args = ap.parse_args()
+    return ap.parse_args(argv)
 
-    chunks = None
-    entries = None
+
+def derive_output_paths(args: argparse.Namespace, entries: list) -> OutputPaths:
+    prefix = register_name_prefix(entries)
+
+    def resolve(opt: Path | bool | None, suffix: str, label: str) -> Path | None:
+        if opt is True:
+            if prefix is None:
+                print(f"No check register entries found; {label} not created")
+                raise SystemExit(1)
+            return Path(f"{prefix}{suffix}")
+        return opt
+
+    csv = resolve(args.csv, ".csv", "CSV")
+    json = resolve(args.json, ".json", "JSON")
+    html = resolve(args.html, "-payees.html", "HTML")
+    chunks_json = resolve(args.chunks_json, "-chunks.json", "chunks JSON")
+    pdf = args.pdf_out
+    if pdf is True:
+        pdf = default_pdf_name(entries)
+        if pdf is None:
+            print("No check register entries found; PDF not created")
+            raise SystemExit(1)
+    return OutputPaths(csv, json, html, chunks_json, pdf)
+
+
+def write_outputs(entries: list, paths: OutputPaths, drop: int) -> None:
+    if paths.csv:
+        write_csv(entries, paths.csv)
+    if paths.json:
+        write_json(entries, paths.json)
+    if paths.html:
+        write_payee_quadtree_html(entries, paths.html, drop=drop)
+
+
+def print_stats(entries: list, paths: OutputPaths, *, rollups: bool, totals: bool) -> None:
+    stats = sanity(entries)
+    print(
+        f"Rows: {stats['count']}  (checks={stats['by_type'].get('check', 0)}, "
+        f"efts={stats['by_type'].get('eft', 0)})",
+    )
+    print(f"Total (non-void): ${stats['total_nonvoid']:,.2f}")
+    if paths.csv:
+        print(f"CSV: {paths.csv}")
+    if paths.json:
+        print(f"JSON: {paths.json}")
+    if paths.html:
+        print(f"HTML: {paths.html}")
+    if rollups:
+        roll = month_rollups(entries)
+        if not roll:
+            print("No month rollups to display.")
+        else:
+            print("\nPer-month rollups (non-void totals):")
+            for (m, y), sums in sorted(roll.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+                print(
+                    f"  {m:02d}/{y}: checks=${sums['checks']:,.2f}  "
+                    f"efts=${sums['efts']:,.2f}  grand=${sums['grand']:,.2f}",
+                )
+    if totals:
+        tot = month_totals(entries)
+        if not tot:
+            print("No month totals to display.")
+        else:
+            print("\nPer-month totals (non-void, deduped):")
+            for (m, y), total in sorted(tot.items(), key=lambda kv: (kv[0][1], kv[0][0])):
+                print(f"  {m:02d}/{y}: ${total:,.2f}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+
     need_chunks = bool(args.chunks_json)
     need_entries = (
         args.csv is not None
@@ -55,101 +132,34 @@ def main() -> None:
         or args.html is not None
         or args.print_rollups
         or args.totals
-        or args.pdf_out is True
-        or args.chunks_json is True
+        or args.pdf_out is not None
+        or need_chunks
     )
+
+    chunks = entries = None
     if need_entries or need_chunks:
         parser = CheckRegisterParser(args.pdf, keep_voided=not args.drop_voided)
         chunks = parser.extract_raw_chunks()
         if need_entries:
             entries = parser.parse_chunks(chunks)
 
-    if entries is not None:
-        prefix = register_name_prefix(entries)
-        if args.csv is True:
-            if prefix is None:
-                print("No check register entries found; CSV not created")
-                sys.exit(1)
-            args.csv = Path(f"{prefix}.csv")
-        if args.json is True:
-            if prefix is None:
-                print("No check register entries found; JSON not created")
-                sys.exit(1)
-            args.json = Path(f"{prefix}.json")
-        if args.html is True:
-            if prefix is None:
-                print("No check register entries found; HTML not created")
-                sys.exit(1)
-            args.html = Path(f"{prefix}-payees.html")
-        if args.chunks_json is True:
-            if prefix is None:
-                print("No check register entries found; chunks JSON not created")
-                sys.exit(1)
-            args.chunks_json = Path(f"{prefix}-chunks.json")
+    paths = derive_output_paths(args, entries or [])
 
-        if args.csv:
-            write_csv(entries, args.csv)
-        if args.json:
-            write_json(entries, args.json)
-        if args.html:
-            write_payee_quadtree_html(entries, args.html, drop=args.drop)
+    if entries:
+        write_outputs(entries, paths, args.drop)
+        if paths.csv or paths.json or paths.html or args.print_rollups or args.totals:
+            print_stats(entries, paths, rollups=args.print_rollups, totals=args.totals)
 
-        if args.csv or args.json or args.html or args.print_rollups or args.totals:
-            stats = sanity(entries)
-            print(
-                f"Rows: {stats['count']}  (checks={stats['by_type'].get('check', 0)}, "
-                f"efts={stats['by_type'].get('eft', 0)})"
-            )
-            print(f"Total (non-void): ${stats['total_nonvoid']:,.2f}")
-            if args.csv:
-                print(f"CSV: {args.csv}")
-            if args.json:
-                print(f"JSON: {args.json}")
-            if args.html:
-                print(f"HTML: {args.html}")
-            if args.print_rollups:
-                roll = month_rollups(entries)
-                if not roll:
-                    print("No month rollups to display.")
-                else:
-                    print("\nPer-month rollups (non-void totals):")
-                    for (m, y), sums in sorted(roll.items(), key=lambda kv: (kv[0][1], kv[0][0])):
-                        print(
-                            f"  {m:02d}/{y}: checks=${sums['checks']:,.2f}  "
-                            f"efts=${sums['efts']:,.2f}  grand=${sums['grand']:,.2f}"
-                        )
-            if args.totals:
-                totals = month_totals(entries)
-                if not totals:
-                    print("No month totals to display.")
-                else:
-                    print("\nPer-month totals (non-void, deduped):")
-                    for (m, y), total in sorted(totals.items(), key=lambda kv: (kv[0][1], kv[0][0])):
-                        print(f"  {m:02d}/{y}: ${total:,.2f}")
+    if need_chunks and chunks is not None and paths.chunks_json:
+        write_chunks(chunks, paths.chunks_json)
 
-    if need_chunks and chunks is not None:
-        if args.chunks_json is True:
-            prefix = register_name_prefix(entries or [])
-            if prefix is None:
-                print("No check register entries found; chunks JSON not created")
-                sys.exit(1)
-            args.chunks_json = Path(f"{prefix}-chunks.json")
-        write_chunks(chunks, args.chunks_json)
-
-    if args.pdf_out:
-        if args.pdf_out is True:
-            out_path = default_pdf_name(entries)
-            if out_path is None:
-                print("No check register entries found; PDF not created")
-                sys.exit(1)
-        else:
-            out_path = args.pdf_out
+    if paths.pdf:
         try:
-            start, end = extract_check_register_pdf(args.pdf, out_path)
+            start, end = extract_check_register_pdf(args.pdf, paths.pdf)
         except ValueError as exc:
             print(f"PDF extraction failed: {exc}")
             sys.exit(1)
-        print(f"PDF: {out_path} (pages {start}-{end})")
+        print(f"PDF: {paths.pdf} (pages {start}-{end})")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,0 +1,67 @@
+import contextlib
+import io
+import tempfile
+from decimal import Decimal
+from pathlib import Path
+import unittest
+
+from check_register.models import CheckEntry
+from check_register.page_extractor import register_name_prefix, default_pdf_name
+from check_register_parser import (
+    parse_args,
+    derive_output_paths,
+    write_outputs,
+    print_stats,
+)
+
+
+class TestCliHelpers(unittest.TestCase):
+    def _entries(self):
+        return [
+            CheckEntry(6, 2025, "check", "", "", "", "", "", "", Decimal("1"), False)
+        ]
+
+    def test_parse_args_defaults(self):
+        args = parse_args(["in.pdf"])
+        self.assertEqual(args.pdf, Path("in.pdf"))
+        self.assertIsNone(args.csv)
+        self.assertFalse(args.print_rollups)
+
+    def test_derive_output_paths(self):
+        entries = self._entries()
+        args = parse_args([
+            "in.pdf",
+            "--csv",
+            "--json",
+            "--html",
+            "--chunks-json",
+            "--pdf",
+        ])
+        paths = derive_output_paths(args, entries)
+        prefix = register_name_prefix(entries)
+        self.assertEqual(paths.csv, Path(f"{prefix}.csv"))
+        self.assertEqual(paths.json, Path(f"{prefix}.json"))
+        self.assertEqual(paths.html, Path(f"{prefix}-payees.html"))
+        self.assertEqual(paths.chunks_json, Path(f"{prefix}-chunks.json"))
+        self.assertEqual(paths.pdf, default_pdf_name(entries))
+
+    def test_write_outputs_and_print_stats(self):
+        entries = self._entries()
+        args = parse_args(["in.pdf", "--csv", "--json", "--html"])
+        paths = derive_output_paths(args, entries)
+        with tempfile.TemporaryDirectory() as td:
+            paths.csv = Path(td, "out.csv")
+            paths.json = Path(td, "out.json")
+            paths.html = Path(td, "out.html")
+            write_outputs(entries, paths, drop=0)
+            self.assertTrue(paths.csv.exists())
+            self.assertTrue(paths.json.exists())
+            self.assertTrue(paths.html.exists())
+            with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+                print_stats(entries, paths, rollups=False, totals=False)
+                out = buf.getvalue()
+        self.assertIn("Rows: 1", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract argument parsing, output path derivation, file writing, and summary printing into dedicated helpers
- Simplify `main` to orchestrate parsing, output generation, and optional PDF/chunk extraction using helpers
- Add unit tests for new CLI helpers

## Testing
- `python -m unittest discover -s tests`

## Suggested Squash Commit Message
- refactor CLI into helpers and add tests

------
https://chatgpt.com/codex/tasks/task_e_68af984656148322bacb1bf9f1f099b4