### PR TITLE
Clarify artifact regeneration instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ If parser changes might affect output, regenerate sample artifacts:
 When tests most naturally use "heavy" artifacts or originals, consider adding a "TODO" around reducing the time required to run the new test
 Test with the smallest artifact possible (or use mocks). 
 
-ALWAYS regenerate artifacts in separate pull request from the code changes that triggered them. Never mix code code changes and data artifacts in a pull request.
+Regenerate artifacts in a separate pull request from the code changes; never combine code changes and data artifacts in the same PR.
 
 ## Data: originals and artifacts
 


### PR DESCRIPTION
## Summary
- Clarify artifact regeneration instructions in the contributing guidelines to ensure code and data artifacts stay in separate pull requests.

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68afa38130f48322854fefdb7fc1f8b7