### PR TITLE
Clarify accuracy test threshold guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ python -m unittest discover -s tests
 ```
 
 Accuracy tests such as `tests/test_june_2025_payees.py`, `tests/test_jul_aug_2025_top_payees.py`, and `tests/test_payee_splitter.py` enforce these thresholds.
-Do not commit code that lowers these thresholds with an explanation (for example that the prior unit test was incorrect in some way)
+Do not lower these thresholds without clear justification (e.g., correcting an incorrect prior unit test).
 
 ## Testing and artifacts
 


### PR DESCRIPTION
## Summary
- clarify that specific accuracy tests enforce thresholds
- warn contributors not to lower thresholds without solid justification

## Testing
- `python -m unittest discover -s tests`

## Suggested squash commit message
- docs: clarify accuracy test threshold guidance

------
https://chatgpt.com/codex/tasks/task_e_68afa37f1960832298495e8fa18408d1