### PR TITLE
Handle relative PDF paths in artifact builder

### DIFF
--- a/scripts/build_register_archive.sh
+++ b/scripts/build_register_archive.sh
@@ -24,6 +24,7 @@ mkdir -p "$pdf_dir" "$csv_dir" "$chunk_dir" "$html_dir"
 
 find "$originals_dir" -type f -name '*.pdf' -print0 | sort -z | \
   while IFS= read -r -d '' packet_pdf; do
+    packet_pdf="$(cd "$(dirname "$packet_pdf")" && pwd)/$(basename "$packet_pdf")"
     tmpdir=$(mktemp -d)
     (
       cd "$tmpdir"

--- a/tests/test_jul_aug_2025_top_payees.py
+++ b/tests/test_jul_aug_2025_top_payees.py
@@ -17,7 +17,7 @@ class TestJulAug2025TopPayees(unittest.TestCase):
     """Ensure parser extracts a reasonable number of top payees by amount."""
 
     def test_minimum_matches(self):
-        chunk_path = ARTIFACT_CHUNKS_DIR / '2025-06-07.json'
+        chunk_path = ARTIFACT_CHUNKS_DIR / '2025-06-07-chunks.json'
         with chunk_path.open() as f:
             chunks = [RowChunk(**c) for c in json.load(f)]
         parser = CheckRegisterParser(chunk_path)

--- a/tests/test_june_2025_payees.py
+++ b/tests/test_june_2025_payees.py
@@ -17,7 +17,7 @@ class TestJune2025Payees(unittest.TestCase):
     """Ensure parser extracts a reasonable number of known June 2025 payees."""
 
     def test_minimum_matches(self):
-        chunk_path = ARTIFACT_CHUNKS_DIR / '2025-06-07.json'
+        chunk_path = ARTIFACT_CHUNKS_DIR / '2025-06-07-chunks.json'
         with chunk_path.open() as f:
             chunks = [RowChunk(**c) for c in json.load(f)]
         parser = CheckRegisterParser(chunk_path)

--- a/tests/test_month_totals_2025_06_07.py
+++ b/tests/test_month_totals_2025_06_07.py
@@ -12,7 +12,7 @@ from check_register.stats import month_totals
 
 class TestMonthTotalsJune2025(unittest.TestCase):
     def test_month_totals_dedup(self):
-        chunk_path = ARTIFACT_CHUNKS_DIR / "2025-06-07.json"
+        chunk_path = ARTIFACT_CHUNKS_DIR / "2025-06-07-chunks.json"
         with chunk_path.open() as f:
             chunks = [RowChunk(**c) for c in json.load(f)]
         parser = CheckRegisterParser(chunk_path)

--- a/tests/test_parse_chunks_basic.py
+++ b/tests/test_parse_chunks_basic.py
@@ -45,7 +45,7 @@ class TestParseChunksBasic(unittest.TestCase):
     def test_letter_run_squeezed(self):
         parser = CheckRegisterParser(Path('dummy'))
         # ``x0`` positions approximate values from
-        # ``data/artifacts/chunks/2025-06-07.json`` entry
+        # ``data/artifacts/chunks/2025-06-07-chunks.json`` entry
         # "3306 06/13/2025 Open Accounts Payable P E R S PE1% - PERS SEIU*".
         # The payee letters are extracted individually and should be merged
         # into "PERS" before splitting the description column.


### PR DESCRIPTION
## Summary
- resolve packet PDF paths to absolute paths before running `check_register_parser`
- fix unit tests to reference renamed `2025-06-07-chunks.json` artifact

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68afbc52b0a48322822b85bcbdd1ddc1