### PR TITLE
Make register archive build portable to older Bash

### DIFF
--- a/scripts/build_register_archive.sh
+++ b/scripts/build_register_archive.sh
@@ -70,9 +70,10 @@ process_packet() {
 
 main() {
   prepare_dirs
-  shopt -s nullglob globstar
-  local packets=("$originals_dir"/**/*.pdf)
-  shopt -u globstar
+  local packets=()
+  while IFS= read -r -d '' packet; do
+    packets+=("$packet")
+  done < <(find "$originals_dir" -name '*.pdf' -print0)
   local total=${#packets[@]}
   local overall_start=$(date +%s)
 


### PR DESCRIPTION
## Summary
- replace globstar `shopt` usage with `find`/`while` loop so script runs on Bash 3.2

## Testing
- `python -m unittest discover -s tests`
- `./scripts/build_register_archive.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0ca57c4488322b125b2bf9474cdb4