### PR TITLE
Add payee shortener utility and tests

### DIFF
--- a/check_register/__init__.py
+++ b/check_register/__init__.py
@@ -3,3 +3,4 @@ from .parser import CheckRegisterParser
 from .outputs import write_csv, write_json, write_chunks
 from .quadtree import write_payee_quadtree_html
 from .stats import sanity, month_rollups, month_totals
+from .payee_shortener import shorten_payee

--- a/check_register/payee_shortener.py
+++ b/check_register/payee_shortener.py
@@ -1,0 +1,60 @@
+import re
+
+SUFFIXES_TO_DROP = [
+    ", INC",
+    ", INC.",
+    ", LLC",
+    ", LLC.",
+    ", CO",
+    ", CO.",
+    ", CORP",
+    ", CORP.",
+    ", LTD",
+    ", LTD.",
+    ", LP",
+    ", LP.",
+    ", LLP",
+    ", LLP.",
+]
+
+PAREN_PATTERNS = [
+    r"\([^)]*formerly[^)]*\)",
+    r"\([^)]*dba [^)]*\)",
+]
+
+WORD_CONTRACTIONS = {
+    "ENTERPRISES": "ENT",
+    "ENGINEERING": "ENG",
+    "SERVICES": "SVCS",
+    "MANAGEMENT": "MGMT",
+    "ASSOCIATION": "ASSOC",
+}
+
+
+def shorten_payee(name: str) -> str:
+    """Return a shortened payee name."""
+    out = name
+
+    for pat in PAREN_PATTERNS:
+        out = re.sub(pat, "", out, flags=re.IGNORECASE)
+
+    out = out.strip()
+
+    changed = True
+    while changed:
+        changed = False
+        upper = out.upper()
+        for suffix in SUFFIXES_TO_DROP:
+            if upper.endswith(suffix):
+                out = out[: -len(suffix)]
+                out = out.rstrip()
+                upper = out.upper()
+                changed = True
+    words_pat = re.compile(
+        r"\b(" + "|".join(map(re.escape, WORD_CONTRACTIONS.keys())) + r")\b",
+        re.IGNORECASE,
+    )
+    out = words_pat.sub(lambda m: WORD_CONTRACTIONS[m.group(0).upper()], out)
+    out = re.sub(r"\s+", " ", out)
+    out = re.sub(r"[.,;:-]+$", "", out)
+    return out.strip()

--- a/tests/test_payee_shortener.py
+++ b/tests/test_payee_shortener.py
@@ -1,0 +1,29 @@
+import unittest
+
+from check_register import shorten_payee
+
+
+class TestPayeeShortener(unittest.TestCase):
+    def test_suffix_removed(self):
+        name = "COMMUNITY CONSERVATION CENTERS, INC."
+        self.assertEqual(shorten_payee(name), "COMMUNITY CONSERVATION CENTERS")
+
+    def test_suffix_and_contraction(self):
+        name = "AMAZON CAPITAL SERVICES, INC."
+        self.assertEqual(shorten_payee(name), "AMAZON CAPITAL SVCS")
+
+    def test_contraction_only(self):
+        name = "WILLDAN FINANCIAL SERVICES"
+        self.assertEqual(shorten_payee(name), "WILLDAN FINANCIAL SVCS")
+
+    def test_parenthetical_removed(self):
+        name = "MIssionSquare (name chg 03-2021 formerly ICMA)"
+        self.assertEqual(shorten_payee(name), "MIssionSquare")
+
+    def test_suffix_llp(self):
+        name = "REDWOOD PUBLIC LAW, LLP"
+        self.assertEqual(shorten_payee(name), "REDWOOD PUBLIC LAW")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add payee shortening helper with suffix trimming, parenthetical removal, and common contractions
- expose `shorten_payee` in package
- cover common payee patterns in new unit tests

## Testing
- `python -m unittest discover -s tests` *(fails: FileNotFoundError: data/originals/2025/Agenda Packet (8.19.2025).pdf)*
- `python -m unittest tests.test_payee_shortener -v`


------
https://chatgpt.com/codex/tasks/task_e_68b0ffa5ac2c832293a6be07f147ec5e