### PR TITLE
Handle revised agenda packet filenames in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,12 +72,17 @@ Regenerate artifacts in a separate pull request from the code changes; never com
 - `data/originals/` holds agenda packet PDFs downloaded from [www.elcerrito.gov](https://www.elcerrito.gov).
 - `data/artifacts/` stores parser outputs such as chunk archives used in tests.
 
+Note: originals may be reissued with revised filenames. For example,
+`Agenda Packet (8.19.2025).pdf` was replaced by
+`Agenda Packet (rev. 8.20.2025).pdf`. Ensure tests reference the current
+filenames and check that referenced files exist.
+
 ## Running the parser
 
 To generate a CSV from the 2025 statements run:
 
 ```bash
-check_register_parser.py data/originals/2025/"Agenda Packet (8.19.2025).pdf" --csv out.csv
+ check_register_parser.py data/originals/2025/"Agenda Packet (rev. 8.20.2025).pdf" --csv out.csv
 ```
 
 Each PDF should log `✔ reconciled`. The resulting CSV confirms the parser still works. Run the parser when modifying code to verify behavior offline.

--- a/tests/test_jul_aug_2025_top_payees.py
+++ b/tests/test_jul_aug_2025_top_payees.py
@@ -18,6 +18,7 @@ class TestJulAug2025TopPayees(unittest.TestCase):
 
     def test_minimum_matches(self):
         chunk_path = ARTIFACT_CHUNKS_DIR / '2025-06-07-chunks.json'
+        self.assertTrue(chunk_path.exists(), f"Missing chunk file: {chunk_path}")
         with chunk_path.open() as f:
             chunks = [RowChunk(**c) for c in json.load(f)]
         parser = CheckRegisterParser(chunk_path)

--- a/tests/test_june_2025_payees.py
+++ b/tests/test_june_2025_payees.py
@@ -18,6 +18,7 @@ class TestJune2025Payees(unittest.TestCase):
 
     def test_minimum_matches(self):
         chunk_path = ARTIFACT_CHUNKS_DIR / '2025-06-07-chunks.json'
+        self.assertTrue(chunk_path.exists(), f"Missing chunk file: {chunk_path}")
         with chunk_path.open() as f:
             chunks = [RowChunk(**c) for c in json.load(f)]
         parser = CheckRegisterParser(chunk_path)

--- a/tests/test_month_totals_2025_06_07.py
+++ b/tests/test_month_totals_2025_06_07.py
@@ -13,6 +13,7 @@ from check_register.stats import month_totals
 class TestMonthTotalsJune2025(unittest.TestCase):
     def test_month_totals_dedup(self):
         chunk_path = ARTIFACT_CHUNKS_DIR / "2025-06-07-chunks.json"
+        self.assertTrue(chunk_path.exists(), f"Missing chunk file: {chunk_path}")
         with chunk_path.open() as f:
             chunks = [RowChunk(**c) for c in json.load(f)]
         parser = CheckRegisterParser(chunk_path)

--- a/tests/test_page_extractor.py
+++ b/tests/test_page_extractor.py
@@ -13,7 +13,8 @@ from check_register.parser import CheckRegisterParser
 
 class TestPageExtractor(unittest.TestCase):
     def test_extract_range_august(self):
-        src = ORIGINALS_DIR / '2025' / 'Agenda Packet (8.19.2025).pdf'
+        src = ORIGINALS_DIR / '2025' / 'Agenda Packet (rev. 8.20.2025).pdf'
+        self.assertTrue(src.exists(), f"Missing original PDF: {src}")
         with tempfile.TemporaryDirectory() as tmpdir:
             out = Path(tmpdir) / 'register.pdf'
             start, end = extract_check_register_pdf(src, out)
@@ -40,6 +41,7 @@ class TestPageExtractor(unittest.TestCase):
 
     def test_extract_range_february(self):
         src = ORIGINALS_DIR / '2025' / 'Agenda Packet (rev. 3.18.2025).pdf'
+        self.assertTrue(src.exists(), f"Missing original PDF: {src}")
         with tempfile.TemporaryDirectory() as tmpdir:
             out = Path(tmpdir) / 'register.pdf'
             start, end = extract_check_register_pdf(src, out)


### PR DESCRIPTION
## Summary
- update August agenda packet reference to "Agenda Packet (rev. 8.20.2025).pdf"
- assert original and artifact files exist in tests
- document that agenda packets may be reissued

## Testing
- `python -m unittest discover -s tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b105962a1c8322a1de4b5008a59aab