### PR TITLE
Shorten payee labels in quadtree

### DIFF
--- a/check_register/quadtree.py
+++ b/check_register/quadtree.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple
 
 from .models import CheckEntry
 from .stats import dedupe_by_number
+from .payee_shortener import shorten_payee
 
 
 def group_payees(entries: List[CheckEntry]) -> Dict[str, List[CheckEntry]]:
@@ -94,6 +95,7 @@ def assemble_quadtree_data(rects: List[Dict[str, float]], payees: Dict[str, List
         nums = [(e.number, e.amount) for e in info]
         checks = ", ".join(f"{n}: ${a:,.2f}" for n, a in nums)
         w, h = r["w"], r["h"]
+        short = shorten_payee(payee)
         data["cx"].append(r["x"] + w / 2)
         data["cy"].append(r["y"] + h / 2)
         data["w"].append(w)
@@ -102,9 +104,9 @@ def assemble_quadtree_data(rects: List[Dict[str, float]], payees: Dict[str, List
         data["amount"].append(r["value"])
         data["description"].append("; ".join(descs))
         data["checks"].append(checks)
-        fits_w = w * 960 >= len(payee) * 7
+        fits_w = w * 960 >= len(short) * 7
         fits_h = h * 600 >= 14
-        data["label"].append(payee if (fits_w and fits_h) else "")
+        data["label"].append(short if (fits_w and fits_h) else "")
     total = sum(data["amount"])
     data["percent"] = [v / total * 100 if total else 0 for v in data["amount"]]
     return data

--- a/tests/test_quadtree_output.py
+++ b/tests/test_quadtree_output.py
@@ -28,6 +28,27 @@ class TestPayeeQuadtreeData(unittest.TestCase):
         data = build_payee_quadtree_data(entries)
         self.assertEqual(data["label"][0], "Alpha Co")
 
+    def test_shortened_label_preserves_original_payee(self):
+        entries = [
+            CheckEntry(
+                6,
+                2025,
+                "check",
+                "1",
+                "06/01/2025",
+                "Open",
+                "Accounts Payable",
+                "Acme Engineering Services, LLC",
+                "desc",
+                Decimal("100.00"),
+                False,
+            )
+        ]
+        data = build_payee_quadtree_data(entries)
+        idx = data["payee"].index("Acme Engineering Services, LLC")
+        self.assertEqual(data["label"][idx], "Acme ENG SVCS")
+        self.assertEqual(data["payee"][idx], "Acme Engineering Services, LLC")
+
     def test_drop_top_payees(self):
         entries = [
             CheckEntry(6, 2025, "check", "1", "06/01/2025", "Open", "Accounts Payable", "CalPERS", "a", Decimal("100.00"), False),


### PR DESCRIPTION
## Summary
- shorten payee names for quadtree labels while keeping original for hover text
- test that long payee labels are shortened without losing original

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68b1d6c8be0c8322a260b82d0c51d046