### PR TITLE
Add payee name length statistics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ pip install --no-index --find-links vendor/wheels-linux -r requirements.txt
 ## Comment style
 
 - Describe current behavior in the present tense; avoid references to past implementations.
+- Do not restate repository policies or coding practices in code comments.
+- Avoid comments that simply repeat prompts or code review feedback.
 
 ## `TODO` comments
 
@@ -71,6 +73,8 @@ Regenerate artifacts in a separate pull request from the code changes; never com
 
 - `data/originals/` holds agenda packet PDFs downloaded from [www.elcerrito.gov](https://www.elcerrito.gov).
 - `data/artifacts/` stores parser outputs such as chunk archives used in tests.
+- The number of data artifacts grows as new agenda packets are added; tests should
+  reference specific files instead of iterating the entire directory.
 
 Note: originals may be reissued with revised filenames. For example,
 `Agenda Packet (8.19.2025).pdf` was replaced by

--- a/check_register/payee_shortener.py
+++ b/check_register/payee_shortener.py
@@ -1,4 +1,6 @@
 import re
+from statistics import mean, median
+from typing import Dict, Iterable
 
 SUFFIXES_TO_DROP = [
     ", INC",
@@ -58,3 +60,20 @@ def shorten_payee(name: str) -> str:
     out = re.sub(r"\s+", " ", out)
     out = re.sub(r"[.,;:-]+$", "", out)
     return out.strip()
+
+
+def name_length_stats(payees: Iterable[str]) -> Dict[str, float]:
+    """Return mean/median lengths and over_30 count for shortened names."""
+    lengths = []
+    over_30 = 0
+    for name in payees:
+        short = shorten_payee(name)
+        lengths.append(len(short))
+        if len(name) > 30 and len(short) > 30:
+            over_30 += 1
+    if lengths:
+        avg = mean(lengths)
+        med = median(lengths)
+    else:
+        avg = med = 0.0
+    return {"mean": avg, "median": med, "over_30": over_30}

--- a/tests/test_payee_name_stats.py
+++ b/tests/test_payee_name_stats.py
@@ -1,0 +1,26 @@
+import csv
+import unittest
+
+from project_paths import ARTIFACT_CSV_DIR
+from check_register.payee_shortener import name_length_stats
+
+
+class TestPayeeNameStats(unittest.TestCase):
+    def test_name_shortening_thresholds(self):
+        payees = []
+        paths = [
+            ARTIFACT_CSV_DIR / "2024-12.csv",
+            ARTIFACT_CSV_DIR / "2025-01.csv",
+            ARTIFACT_CSV_DIR / "2025-02.csv",
+        ]
+        for path in paths:
+            with path.open() as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    payees.append(row["payee"])
+        lengths = [len(p) for p in payees]
+        original_mean = sum(lengths) / len(lengths)
+        original_over_30 = sum(1 for l in lengths if l > 30)
+        stats = name_length_stats(payees)
+        self.assertLess(stats["mean"], original_mean * 0.95)
+        self.assertLessEqual(stats["over_30"], original_over_30 * 0.6)


### PR DESCRIPTION
## Summary
- compute mean/median and long-name counts for shortened payees
- test payee name shortening using relative thresholds
- document data artifact growth and discourage restating policies in comments

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1d782e8c88322afbcbc0d3d22593d