### PR TITLE
Add payee list tracking and CLI option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ pip install --no-index --find-links vendor/wheels-linux -r requirements.txt
 - Split complex logic into helpers rather than relying on heavy comments.
 - When adding code, mimic the style, spacing, separations, line-feeds and line layouts of the surrounding code
 - Match existing looping patterns (for-loops, comprehensions) and other common idioms.
+- Keep side effects local: helpers should either mutate state or format output, but not both.
 
 ## Comment style
 

--- a/check_register/__init__.py
+++ b/check_register/__init__.py
@@ -2,5 +2,5 @@ from .models import CheckEntry, RowChunk
 from .parser import CheckRegisterParser
 from .outputs import write_csv, write_json, write_chunks
 from .quadtree import write_payee_quadtree_html
-from .stats import sanity, month_rollups, month_totals
+from .stats import sanity, month_rollups, month_totals, payee_totals
 from .payee_shortener import shorten_payee

--- a/check_register/payees.py
+++ b/check_register/payees.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from typing import Dict, List, Set
+
+from .models import CheckEntry
+from .stats import payee_totals
+
+
+def update_payees(entries: List[CheckEntry], path: Path, threshold: int = 10) -> Dict[str, object]:
+    """Merge payees from entries with an existing list and write the result."""
+    existing: Set[str] = set()
+    if path.exists():
+        existing = {
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+    current = {e.payee for e in entries}
+    merged = sorted(existing | current)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(merged) + ("\n" if merged else ""), encoding="utf-8")
+
+    new_all = sorted(current - existing)
+    listed = new_all if len(new_all) < threshold else []
+    totals = payee_totals(entries)
+    new_amounts: Dict[str, Decimal] = {p: totals[p] for p in listed}
+    return {
+        "total_payees": len(merged),
+        "new_payee_count": len(new_all),
+        "new_payees": listed,
+        "new_payee_amounts": new_amounts,
+    }

--- a/check_register/payees.py
+++ b/check_register/payees.py
@@ -8,7 +8,7 @@ from .models import CheckEntry
 from .stats import payee_totals, sanity
 
 
-def update_payees(entries: List[CheckEntry], path: Path, threshold: int = 10) -> Dict[str, object]:
+def update_payees(entries: List[CheckEntry], path: Path) -> Dict[str, object]:
     """Merge payees from entries with an existing list and write the result."""
     existing: Set[str] = set()
     if path.exists():
@@ -23,38 +23,36 @@ def update_payees(entries: List[CheckEntry], path: Path, threshold: int = 10) ->
     path.write_text("\n".join(merged) + ("\n" if merged else ""), encoding="utf-8")
 
     new_all = sorted(current - existing)
-    listed = new_all if len(new_all) < threshold else []
-    totals = payee_totals(entries)
-    new_amounts: Dict[str, Decimal] = {p: totals[p] for p in listed}
     return {
         "total_payees": len(merged),
-        "new_payee_count": len(new_all),
-        "new_payees": listed,
-        "new_payee_amounts": new_amounts,
+        "new_payees": new_all,
     }
 
 
 def payee_summary(
-    entries: List[CheckEntry], path: Path, *, default: bool, threshold: int = 10
+    entries: List[CheckEntry],
+    path: Path,
+    info: Dict[str, object],
+    *,
+    default: bool,
+    threshold: int = 10,
 ) -> List[str]:
-    """Update payee file and return summary lines."""
-    info = update_payees(entries, path, threshold)
+    """Return summary lines for a payee update."""
     if default:
         return [f"Payees: {info['total_payees']} (written to {path})"]
 
-    lines: List[str] = []
-    cnt = info["new_payee_count"]
+    cnt = len(info["new_payees"])
     if cnt == 0:
-        lines.append(f"No new payees (total {info['total_payees']})")
-        return lines
+        return [f"No new payees (total {info['total_payees']})"]
 
-    lines.append(
+    lines = [
         f"Added {cnt} new payees to {path} (total {info['total_payees']})"
-    )
-    if info["new_payees"]:
+    ]
+    if cnt < threshold:
+        totals = payee_totals(entries)
         total_nonvoid = sanity(entries)["total_nonvoid"]
         for payee in info["new_payees"]:
-            amt = info["new_payee_amounts"][payee]
+            amt = totals.get(payee, Decimal("0"))
             pct = (amt / total_nonvoid * 100) if total_nonvoid else 0
             lines.append(f"  {payee} ({pct:.2f}%)")
     return lines

--- a/check_register/payees.py
+++ b/check_register/payees.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List, Set
 
 from .models import CheckEntry
-from .stats import payee_totals
+from .stats import payee_totals, sanity
 
 
 def update_payees(entries: List[CheckEntry], path: Path, threshold: int = 10) -> Dict[str, object]:
@@ -32,3 +32,29 @@ def update_payees(entries: List[CheckEntry], path: Path, threshold: int = 10) ->
         "new_payees": listed,
         "new_payee_amounts": new_amounts,
     }
+
+
+def payee_summary(
+    entries: List[CheckEntry], path: Path, *, default: bool, threshold: int = 10
+) -> List[str]:
+    """Update payee file and return summary lines."""
+    info = update_payees(entries, path, threshold)
+    if default:
+        return [f"Payees: {info['total_payees']} (written to {path})"]
+
+    lines: List[str] = []
+    cnt = info["new_payee_count"]
+    if cnt == 0:
+        lines.append(f"No new payees (total {info['total_payees']})")
+        return lines
+
+    lines.append(
+        f"Added {cnt} new payees to {path} (total {info['total_payees']})"
+    )
+    if info["new_payees"]:
+        total_nonvoid = sanity(entries)["total_nonvoid"]
+        for payee in info["new_payees"]:
+            amt = info["new_payee_amounts"][payee]
+            pct = (amt / total_nonvoid * 100) if total_nonvoid else 0
+            lines.append(f"  {payee} ({pct:.2f}%)")
+    return lines

--- a/check_register/stats.py
+++ b/check_register/stats.py
@@ -62,3 +62,11 @@ def month_totals(entries: List[CheckEntry]) -> Dict[Tuple[int, int], Decimal]:
         month_key = (dt.month, dt.year)
         out[month_key] = out.get(month_key, Decimal("0.00")) + e.amount
     return out
+
+def payee_totals(entries: List[CheckEntry]) -> Dict[str, Decimal]:
+    """Return summed amounts per payee, skipping voided rows."""
+    out: Dict[str, Decimal] = {}
+    nonvoid = [e for e in entries if not e.voided]
+    for e in dedupe_by_number(nonvoid):
+        out[e.payee] = out.get(e.payee, Decimal("0.00")) + e.amount
+    return out

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -23,7 +23,7 @@ from check_register.page_extractor import (
     default_pdf_name,
     register_name_prefix,
 )
-from check_register.payees import update_payees
+from check_register.payees import payee_summary
 
 
 @dataclass
@@ -54,14 +54,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     ap.add_argument(
         "--pdf", nargs="?", type=Path, const=True, dest="pdf_out", default=None, help="Extract check register pages to a PDF",
     )
-    ap.add_argument(
-        "--payees",
-        nargs="?",
-        type=Path,
-        const=True,
-        default=None,
-        help="Write/update payee list (optionally to PATH)",
-    )
+    ap.add_argument("--payees", nargs="?", type=Path, const=True, default=None, help="Write/update payee list (optionally to PATH)")
     return ap.parse_args(argv)
 
 
@@ -161,28 +154,10 @@ def main(argv: list[str] | None = None) -> None:
         write_outputs(entries, paths, args.drop)
         if paths.csv or paths.json or paths.html or args.print_rollups or args.totals:
             print_stats(entries, paths, rollups=args.print_rollups, totals=args.totals)
-        if paths.payees_txt:
-            info = update_payees(entries, paths.payees_txt)
-            if args.payees is True:
-                print(f"Payees: {info['total_payees']} (written to {paths.payees_txt})")
-            else:
-                cnt = info["new_payee_count"]
-                if cnt == 0:
-                    print(f"No new payees (total {info['total_payees']})")
-                else:
-                    print(
-                        f"Added {cnt} new payees to {paths.payees_txt} "
-                        f"(total {info['total_payees']})"
-                    )
-                    if info["new_payees"]:
-                        total_nonvoid = sanity(entries)["total_nonvoid"]
-                        for payee in info["new_payees"]:
-                            pct = (
-                                info["new_payee_amounts"][payee] / total_nonvoid * 100
-                                if total_nonvoid
-                                else 0
-                            )
-                            print(f"  {payee} ({pct:.2f}%)")
+    if paths.payees_txt and entries is not None:
+        lines = payee_summary(entries, paths.payees_txt, default=args.payees is True)
+        for line in lines:
+            print(line)
 
     if need_chunks and chunks is not None and paths.chunks_json:
         write_chunks(chunks, paths.chunks_json)

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -23,7 +23,7 @@ from check_register.page_extractor import (
     default_pdf_name,
     register_name_prefix,
 )
-from check_register.payees import payee_summary
+from check_register.payees import update_payees, payee_summary
 
 
 @dataclass
@@ -155,7 +155,8 @@ def main(argv: list[str] | None = None) -> None:
         if paths.csv or paths.json or paths.html or args.print_rollups or args.totals:
             print_stats(entries, paths, rollups=args.print_rollups, totals=args.totals)
     if paths.payees_txt and entries is not None:
-        lines = payee_summary(entries, paths.payees_txt, default=args.payees is True)
+        info = update_payees(entries, paths.payees_txt)
+        lines = payee_summary(entries, paths.payees_txt, info, default=args.payees is True)
         for line in lines:
             print(line)
 

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -23,6 +23,7 @@ from check_register.page_extractor import (
     default_pdf_name,
     register_name_prefix,
 )
+from check_register.payees import update_payees
 
 
 @dataclass
@@ -32,6 +33,7 @@ class OutputPaths:
     html: Path | None = None
     chunks_json: Path | None = None
     pdf: Path | None = None
+    payees_txt: Path | None = None
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -52,6 +54,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     ap.add_argument(
         "--pdf", nargs="?", type=Path, const=True, dest="pdf_out", default=None, help="Extract check register pages to a PDF",
     )
+    ap.add_argument(
+        "--payees",
+        nargs="?",
+        type=Path,
+        const=True,
+        default=None,
+        help="Write/update payee list (optionally to PATH)",
+    )
     return ap.parse_args(argv)
 
 
@@ -71,12 +81,13 @@ def derive_output_paths(args: argparse.Namespace, entries: list) -> OutputPaths:
     html = resolve(args.html, "-payees.html", "HTML")
     chunks_json = resolve(args.chunks_json, "-chunks.json", "chunks JSON")
     pdf = args.pdf_out
+    payees_txt = resolve(args.payees, "-payees.txt", "payees list")
     if pdf is True:
         pdf = default_pdf_name(entries)
         if pdf is None:
             print("No check register entries found; PDF not created")
             raise SystemExit(1)
-    return OutputPaths(csv, json, html, chunks_json, pdf)
+    return OutputPaths(csv, json, html, chunks_json, pdf, payees_txt)
 
 
 def write_outputs(entries: list, paths: OutputPaths, drop: int) -> None:
@@ -134,6 +145,7 @@ def main(argv: list[str] | None = None) -> None:
         or args.totals
         or args.pdf_out is not None
         or need_chunks
+        or args.payees is not None
     )
 
     chunks = entries = None
@@ -149,6 +161,28 @@ def main(argv: list[str] | None = None) -> None:
         write_outputs(entries, paths, args.drop)
         if paths.csv or paths.json or paths.html or args.print_rollups or args.totals:
             print_stats(entries, paths, rollups=args.print_rollups, totals=args.totals)
+        if paths.payees_txt:
+            info = update_payees(entries, paths.payees_txt)
+            if args.payees is True:
+                print(f"Payees: {info['total_payees']} (written to {paths.payees_txt})")
+            else:
+                cnt = info["new_payee_count"]
+                if cnt == 0:
+                    print(f"No new payees (total {info['total_payees']})")
+                else:
+                    print(
+                        f"Added {cnt} new payees to {paths.payees_txt} "
+                        f"(total {info['total_payees']})"
+                    )
+                    if info["new_payees"]:
+                        total_nonvoid = sanity(entries)["total_nonvoid"]
+                        for payee in info["new_payees"]:
+                            pct = (
+                                info["new_payee_amounts"][payee] / total_nonvoid * 100
+                                if total_nonvoid
+                                else 0
+                            )
+                            print(f"  {payee} ({pct:.2f}%)")
 
     if need_chunks and chunks is not None and paths.chunks_json:
         write_chunks(chunks, paths.chunks_json)

--- a/tests/test_payee_summary.py
+++ b/tests/test_payee_summary.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import unittest
 
 from check_register.models import CheckEntry
-from check_register.payees import payee_summary
+from check_register.payees import update_payees, payee_summary
 
 
 class TestPayeeSummary(unittest.TestCase):
@@ -15,7 +15,8 @@ class TestPayeeSummary(unittest.TestCase):
         ]
         with tempfile.TemporaryDirectory() as td:
             path = Path(td, "payees.txt")
-            lines = payee_summary(entries, path, default=True)
+            info = update_payees(entries, path)
+            lines = payee_summary(entries, path, info, default=True)
             self.assertEqual(path.read_text().splitlines(), ["Alpha", "Beta"])
             self.assertEqual(lines, [f"Payees: 2 (written to {path})"])
 
@@ -28,7 +29,8 @@ class TestPayeeSummary(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             path = Path(td, "existing.txt")
             path.write_text("Alpha\n", encoding="utf-8")
-            lines = payee_summary(entries, path, default=False)
+            info = update_payees(entries, path)
+            lines = payee_summary(entries, path, info, default=False)
             self.assertEqual(path.read_text().splitlines(), ["Alpha", "Beta", "Gamma"])
             self.assertEqual(lines[0], f"Added 2 new payees to {path} (total 3)")
             self.assertIn("Beta (25.00%)", lines[1])

--- a/tests/test_payee_summary.py
+++ b/tests/test_payee_summary.py
@@ -1,0 +1,39 @@
+import tempfile
+from decimal import Decimal
+from pathlib import Path
+import unittest
+
+from check_register.models import CheckEntry
+from check_register.payees import payee_summary
+
+
+class TestPayeeSummary(unittest.TestCase):
+    def test_default(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "1", "", "", "", "Alpha", "", Decimal("100"), False),
+            CheckEntry(6, 2025, "check", "2", "", "", "", "Beta", "", Decimal("200"), False),
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td, "payees.txt")
+            lines = payee_summary(entries, path, default=True)
+            self.assertEqual(path.read_text().splitlines(), ["Alpha", "Beta"])
+            self.assertEqual(lines, [f"Payees: 2 (written to {path})"])
+
+    def test_update(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "1", "", "", "", "Alpha", "", Decimal("50"), False),
+            CheckEntry(6, 2025, "check", "2", "", "", "", "Beta", "", Decimal("50"), False),
+            CheckEntry(6, 2025, "check", "3", "", "", "", "Gamma", "", Decimal("100"), False),
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td, "existing.txt")
+            path.write_text("Alpha\n", encoding="utf-8")
+            lines = payee_summary(entries, path, default=False)
+            self.assertEqual(path.read_text().splitlines(), ["Alpha", "Beta", "Gamma"])
+            self.assertEqual(lines[0], f"Added 2 new payees to {path} (total 3)")
+            self.assertIn("Beta (25.00%)", lines[1])
+            self.assertIn("Gamma (50.00%)", lines[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_payees_cli.py
+++ b/tests/test_payees_cli.py
@@ -1,0 +1,73 @@
+import contextlib
+import io
+import os
+import tempfile
+from decimal import Decimal
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+from check_register.models import CheckEntry
+from check_register_parser import main
+
+
+class TestPayeesCli(unittest.TestCase):
+    def _entries(self):
+        return [
+            CheckEntry(6, 2025, "check", "1", "", "", "", "Alpha", "", Decimal("100"), False),
+            CheckEntry(6, 2025, "check", "2", "", "", "", "Beta", "", Decimal("200"), False),
+        ]
+
+    def test_payees_default_path(self):
+        entries = self._entries()
+        with tempfile.TemporaryDirectory() as td:
+            argv = ["check_register_parser.py", "in.pdf", "--payees"]
+            with patch("check_register_parser.CheckRegisterParser") as MockParser, \
+                 patch("sys.argv", argv):
+                inst = MockParser.return_value
+                inst.extract_raw_chunks.return_value = []
+                inst.parse_chunks.return_value = entries
+                cwd = os.getcwd()
+                os.chdir(td)
+                try:
+                    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+                        main()
+                        out = buf.getvalue()
+                finally:
+                    os.chdir(cwd)
+            payee_file = Path(td, "2025-06-payees.txt")
+            self.assertTrue(payee_file.exists())
+            self.assertEqual(payee_file.read_text().splitlines(), ["Alpha", "Beta"])
+            self.assertIn("Payees: 2", out)
+
+    def test_payees_existing_file(self):
+        entries = [
+            CheckEntry(6, 2025, "check", "1", "", "", "", "Alpha", "", Decimal("50"), False),
+            CheckEntry(6, 2025, "check", "2", "", "", "", "Beta", "", Decimal("50"), False),
+            CheckEntry(6, 2025, "check", "3", "", "", "", "Gamma", "", Decimal("100"), False),
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            existing = Path(td, "existing.txt")
+            existing.write_text("Alpha\n", encoding="utf-8")
+            argv = ["check_register_parser.py", "in.pdf", "--payees", str(existing)]
+            with patch("check_register_parser.CheckRegisterParser") as MockParser, \
+                 patch("sys.argv", argv):
+                inst = MockParser.return_value
+                inst.extract_raw_chunks.return_value = []
+                inst.parse_chunks.return_value = entries
+                cwd = os.getcwd()
+                os.chdir(td)
+                try:
+                    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+                        main()
+                        out = buf.getvalue()
+                finally:
+                    os.chdir(cwd)
+            self.assertEqual(existing.read_text().splitlines(), ["Alpha", "Beta", "Gamma"])
+            self.assertIn("Added 2 new payees", out)
+            self.assertIn("Beta (25.00%)", out)
+            self.assertIn("Gamma (50.00%)", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `--payees` CLI flag to write or update a payee list and report newly seen vendors
- compute per-payee totals to support percent-of-register summaries
- maintain and merge payee text files via `update_payees`

## Testing
- `python -m unittest discover -s tests`

## Suggested squash commit message
- feat: support payee list updates and summaries

------
https://chatgpt.com/codex/tasks/task_e_68b1e531f3d88322bf9588c37335939c