### PR TITLE
Improve missing file handling in CLI parser

### DIFF
--- a/check_register/parser.py
+++ b/check_register/parser.py
@@ -183,6 +183,8 @@ class CheckRegisterParser:
     def extract_raw_chunks(self) -> List[RowChunk]:
         chunks: List[RowChunk] = []
         state = _ExtractState()
+        if not self.pdf_path.is_file():
+            raise FileNotFoundError(f"PDF not found: {self.pdf_path}")
 
         logging.getLogger("pdfminer").setLevel(logging.ERROR)
         with pdfplumber.open(self.pdf_path) as pdf:

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -125,6 +125,10 @@ def print_stats(entries: list, paths: OutputPaths, *, rollups: bool, totals: boo
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
 
+    if not args.pdf.is_file():
+        print(f"Input PDF not found: {args.pdf}")
+        sys.exit(1)
+
     need_chunks = bool(args.chunks_json)
     need_entries = (
         args.csv is not None
@@ -139,7 +143,11 @@ def main(argv: list[str] | None = None) -> None:
     chunks = entries = None
     if need_entries or need_chunks:
         parser = CheckRegisterParser(args.pdf, keep_voided=not args.drop_voided)
-        chunks = parser.extract_raw_chunks()
+        try:
+            chunks = parser.extract_raw_chunks()
+        except FileNotFoundError as exc:
+            print(exc)
+            sys.exit(1)
         if need_entries:
             entries = parser.parse_chunks(chunks)
 


### PR DESCRIPTION
## Summary
- Raise a clear FileNotFoundError when a PDF is missing
- Check for input PDF existence in the CLI and exit gracefully

## Testing
- `python -m unittest discover -s tests`
- `./check_register_parser.py data/originals/2025/Agenda\ Packet\ \(8.19.2025\).pdf --html 2025-06-07-new5-payees.html --drop 4 --totals --csv --pdf`

------
https://chatgpt.com/codex/tasks/task_e_68b1e81589248322b7b7c4766ee7c010