### PR TITLE
Split payee update into merge and write helpers

### DIFF
--- a/check_register/payees.py
+++ b/check_register/payees.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from decimal import Decimal
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Tuple
 
 from .models import CheckEntry
 from .stats import payee_totals, sanity
 
 
-def update_payees(entries: List[CheckEntry], path: Path) -> Dict[str, object]:
-    """Merge payees from entries with an existing list and write the result."""
+def merge_payees(
+    entries: List[CheckEntry], path: Path
+) -> Tuple[List[str], Dict[str, object]]:
+    """Return merged payee list and summary info."""
     existing: Set[str] = set()
     if path.exists():
         existing = {
@@ -19,14 +21,20 @@ def update_payees(entries: List[CheckEntry], path: Path) -> Dict[str, object]:
         }
     current = {e.payee for e in entries}
     merged = sorted(existing | current)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(merged) + ("\n" if merged else ""), encoding="utf-8")
-
     new_all = sorted(current - existing)
-    return {
+    info = {
         "total_payees": len(merged),
         "new_payees": new_all,
     }
+    return merged, info
+
+
+def write_payees(payees: List[str], path: Path) -> None:
+    """Write payees to path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(payees) + ("\n" if payees else ""), encoding="utf-8"
+    )
 
 
 def payee_summary(

--- a/check_register_parser.py
+++ b/check_register_parser.py
@@ -23,7 +23,7 @@ from check_register.page_extractor import (
     default_pdf_name,
     register_name_prefix,
 )
-from check_register.payees import update_payees, payee_summary
+from check_register.payees import merge_payees, write_payees, payee_summary
 
 
 @dataclass
@@ -159,8 +159,11 @@ def main(argv: list[str] | None = None) -> None:
         if paths.csv or paths.json or paths.html or args.print_rollups or args.totals:
             print_stats(entries, paths, rollups=args.print_rollups, totals=args.totals)
     if paths.payees_txt and entries is not None:
-        info = update_payees(entries, paths.payees_txt)
-        lines = payee_summary(entries, paths.payees_txt, info, default=args.payees is True)
+        payees, info = merge_payees(entries, paths.payees_txt)
+        write_payees(payees, paths.payees_txt)
+        lines = payee_summary(
+            entries, paths.payees_txt, info, default=args.payees is True
+        )
         for line in lines:
             print(line)
 

--- a/tests/test_payee_summary.py
+++ b/tests/test_payee_summary.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import unittest
 
 from check_register.models import CheckEntry
-from check_register.payees import update_payees, payee_summary
+from check_register.payees import merge_payees, write_payees, payee_summary
 
 
 class TestPayeeSummary(unittest.TestCase):
@@ -15,7 +15,8 @@ class TestPayeeSummary(unittest.TestCase):
         ]
         with tempfile.TemporaryDirectory() as td:
             path = Path(td, "payees.txt")
-            info = update_payees(entries, path)
+            payees, info = merge_payees(entries, path)
+            write_payees(payees, path)
             lines = payee_summary(entries, path, info, default=True)
             self.assertEqual(path.read_text().splitlines(), ["Alpha", "Beta"])
             self.assertEqual(lines, [f"Payees: 2 (written to {path})"])
@@ -29,7 +30,8 @@ class TestPayeeSummary(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             path = Path(td, "existing.txt")
             path.write_text("Alpha\n", encoding="utf-8")
-            info = update_payees(entries, path)
+            payees, info = merge_payees(entries, path)
+            write_payees(payees, path)
             lines = payee_summary(entries, path, info, default=False)
             self.assertEqual(path.read_text().splitlines(), ["Alpha", "Beta", "Gamma"])
             self.assertEqual(lines[0], f"Added 2 new payees to {path} (total 3)")


### PR DESCRIPTION
## Summary
- Separate payee merging from file persistence with new `merge_payees` and `write_payees` helpers
- Update CLI and tests to use new payee helpers

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68b3f0a5321c832295ab37d9f398982a