### PR TITLE
Clarify missing amount chunk test

### DIFF
--- a/check_register/parser.py
+++ b/check_register/parser.py
@@ -261,6 +261,10 @@ class CheckRegisterParser:
             else:
                 payee, desc = self._split_payee_desc_block(block)
 
+        if amount is None:
+            logging.warning("Missing amount in row: %s", " | ".join(chunk.lines))
+            amount = Decimal("0.00")
+
         return CheckEntry(
             section_month=chunk.section_month,
             section_year=chunk.section_year,
@@ -271,7 +275,7 @@ class CheckRegisterParser:
             source=source.strip(),
             payee=payee,
             description=desc,
-            amount=amount if amount is not None else Decimal("0.00"),
+            amount=amount,
             voided=voided,
         )
 

--- a/tests/test_parse_chunk_cases.py
+++ b/tests/test_parse_chunk_cases.py
@@ -1,0 +1,45 @@
+import unittest
+from pathlib import Path
+from decimal import Decimal
+
+from check_register import CheckRegisterParser, RowChunk
+from check_register.models import PositionedWord
+
+
+class TestParseChunkCases(unittest.TestCase):
+    def test_missing_amount_warns_and_defaults_to_zero(self):
+        parser = CheckRegisterParser(Path('dummy'))
+        # Original row from ``data/artifacts/chunks/2025-04.json`` entry 92736:
+        # 1000 06/01/2025 Open Accounts Payable CITY OF RICHMOND Fire services $1,234.56
+        # The "$1,234.56" amount is removed for this test so the parser receives no amount:
+        # 1000 06/01/2025 Open Accounts Payable CITY OF RICHMOND Fire services
+        line_words = [
+            [
+                PositionedWord(text='1000', x0=7.8),
+                PositionedWord(text='06/01/2025', x0=52.0),
+                PositionedWord(text='Open', x0=85.0),
+                PositionedWord(text='Accounts', x0=214.2),
+                PositionedWord(text='Payable', x0=238.2),
+                PositionedWord(text='CITY', x0=287.6),
+                PositionedWord(text='OF', x0=300.0),
+                PositionedWord(text='RICHMOND', x0=314.0),
+                PositionedWord(text='Fire', x0=444.2),
+                PositionedWord(text='services', x0=460.3),
+                # amount intentionally removed
+            ]
+        ]
+        chunk = RowChunk(
+            section_month=6,
+            section_year=2025,
+            ap_type='check',
+            lines=['1000 06/01/2025 Open Accounts Payable CITY OF RICHMOND Fire services'],
+            line_words=line_words,
+        )
+        with self.assertLogs(level='WARNING') as logs:
+            entry = parser.parse_chunks([chunk])[0]
+        self.assertIn('Missing amount in row', logs.output[0])
+        self.assertEqual(entry.amount, Decimal('0'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- warn when a row lacks an amount and default to zero
- test the warning when the amount token is intentionally removed

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68b48b59a3a08322867d0bacfc7eed56