### PR TITLE
lighten quadtree colors

### DIFF
--- a/check_register/quadtree.py
+++ b/check_register/quadtree.py
@@ -176,7 +176,8 @@ def make_quadtree_figure(data: Dict[str, List], title: str | None = None):
     source = ColumnDataSource(data)
     low = min(data["amount"]) if data["amount"] else 0
     high = max(data["amount"]) if data["amount"] else 1
-    color_map = linear_cmap("amount", Viridis256, low, high)
+    palette = Viridis256[64:]  # skip darker colors for readability
+    color_map = linear_cmap("amount", palette, low, high)
     return _build_quadtree_plot(source, color_map, title)
 
 


### PR DESCRIPTION
## Summary
- make payee quadtree HTML use lighter colors for better readability

## Testing
- `python -m unittest discover -s tests`
- `python check_register_parser.py data/originals/2025/'Agenda Packet (rev. 8.20.2025).pdf' --csv out.csv`


------
https://chatgpt.com/codex/tasks/task_e_68bcaf058040832281a6a28875bf4872