### PR TITLE
Fix fund update extraction for May 2025 packet

### DIFF
--- a/fund_update/page_extractor.py
+++ b/fund_update/page_extractor.py
@@ -4,19 +4,31 @@ import re
 from pathlib import Path
 from typing import List
 
-import pdfplumber
 import pypdfium2 as pdfium
 
-_FUND_UPDATE_PATTERN = re.compile(r"GENERAL\s+FUND\s+BUDGET\s+UPDATE", re.IGNORECASE)
+_FUND_UPDATE_PATTERN = re.compile(r"GENERAL\s+FUND(?:\s+\w+){0,3}\s+UPDATE", re.IGNORECASE)
+_PAGE_COUNT_PATTERN = re.compile(
+    r"Page\s+(?P<current>\d{1,2})\s+of\s+(?P<total>\d{1,2})", re.IGNORECASE
+)
 _DATE_PATTERN = re.compile(
     r"\((?:rev\.\s*)?(?P<month>\d{1,2})\.(?P<day>\d{1,2})\.(?P<year>\d{4})\)",
     re.IGNORECASE,
 )
 
 
-def _page_contains_update(text: str) -> bool:
-    normalized = " ".join(text.split())
-    return bool(_FUND_UPDATE_PATTERN.search(normalized))
+def _normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _anchor_page_count(text: str) -> int | None:
+    match = _PAGE_COUNT_PATTERN.search(text)
+    if not match:
+        return None
+    if int(match.group("current")) != 1:
+        return None
+    if not _FUND_UPDATE_PATTERN.search(text):
+        return None
+    return int(match.group("total"))
 
 
 def find_fund_update_pages(pdf_path: Path) -> List[int]:
@@ -25,12 +37,49 @@ def find_fund_update_pages(pdf_path: Path) -> List[int]:
     if not pdf_path.exists():
         raise FileNotFoundError(pdf_path)
 
-    matches: List[int] = []
-    with pdfplumber.open(pdf_path) as pdf:
-        for index, page in enumerate(pdf.pages, start=1):
-            text = page.extract_text() or ""
-            if _page_contains_update(text):
-                matches.append(index)
+    doc = pdfium.PdfDocument(str(pdf_path))
+    normalized_pages: List[str] = []
+    anchor_index: int | None = None
+    anchor_total: int | None = None
+
+    try:
+        total_pages = len(doc)
+        for page_number in range(total_pages):
+            page = doc.get_page(page_number)
+            text_page = page.get_textpage()
+            normalized = _normalize(text_page.get_text_range() or "")
+            normalized_pages.append(normalized)
+            text_page.close()
+            page.close()
+
+            if anchor_index is None:
+                count = _anchor_page_count(normalized)
+                if count is not None:
+                    anchor_index = page_number + 1
+                    anchor_total = count
+                    break
+
+        if anchor_index is not None and anchor_total is not None:
+            pages = set(range(anchor_index, min(anchor_index + anchor_total, total_pages + 1)))
+            previous = anchor_index - 1
+            while previous >= 1:
+                prev_text = normalized_pages[previous - 1].lower()
+                if "general fund" not in prev_text or "update" not in prev_text:
+                    break
+                pages.add(previous)
+                previous -= 1
+            return sorted(pages)
+
+        for page_number in range(len(normalized_pages), total_pages):
+            page = doc.get_page(page_number)
+            text_page = page.get_textpage()
+            normalized_pages.append(_normalize(text_page.get_text_range() or ""))
+            text_page.close()
+            page.close()
+    finally:
+        doc.close()
+
+    matches = [index + 1 for index, text in enumerate(normalized_pages) if _FUND_UPDATE_PATTERN.search(text)]
     if not matches:
         raise ValueError("General Fund Budget Update pages not found")
     return matches

--- a/tests/test_fund_update_extractor.py
+++ b/tests/test_fund_update_extractor.py
@@ -12,6 +12,7 @@ from fund_update.page_extractor import (
     find_fund_update_pages,
 )
 from fund_update_parser import main as fund_update_main
+from project_paths import ORIGINALS_DIR
 
 
 class FundUpdatePdfBuilder:
@@ -154,6 +155,26 @@ class TestFundUpdateExtractor(unittest.TestCase):
             with contextlib.redirect_stdout(io.StringIO()):
                 fund_update_main(argv)
             self.assertTrue(out_path.exists())
+
+    def test_may_2025_packet_pages(self):
+        src = ORIGINALS_DIR / "2025" / "Agenda Packet (rev. 5.7.2025).pdf"
+        self.assertTrue(src.exists(), f"Missing original PDF: {src}")
+
+        pages = find_fund_update_pages(src)
+        self.assertEqual(pages, [537, 538, 539, 540, 541, 542])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "fund-update.pdf"
+            extracted = extract_fund_update_pdf(src, out)
+            self.assertEqual(extracted, pages)
+
+            with pdfplumber.open(out) as pdf:
+                self.assertEqual(len(pdf.pages), len(pages))
+                first_text = (pdf.pages[0].extract_text() or "").lower()
+                self.assertIn("general fund budget quarterly update", first_text)
+                last_text = (pdf.pages[-1].extract_text() or "").lower()
+                self.assertIn("general fund", last_text)
+                self.assertIn("fund balance", last_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- broaden the General Fund update pattern and detect the "Page 1 of N" anchor to include the entire attachment set
- switch fund update page detection to pdfium and add an integration test covering the May 7, 2025 agenda packet

## Testing
- python -m unittest discover -s tests

Suggested squash commit message: Fix fund update extraction for May 2025 packet

------
https://chatgpt.com/codex/tasks/task_e_68c857fdb3d48322b9617d13c41cb701