### PR TITLE
Extend archive rebuild script to emit fund update PDFs

### DIFF
--- a/scripts/build_register_archive.sh
+++ b/scripts/build_register_archive.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Generate register artifacts for all agenda packet PDFs under the originals
 # directory using the check_register_parser CLI. Artifacts are stored under
 # data/artifacts by default. Outputs include register PDFs, CSVs, chunk JSON,
-# and payee quadtree HTML.
+# payee quadtree HTML, and extracted General Fund Budget Update PDFs.
 
 if [[ $# -gt 2 ]]; then
   echo "Usage: $0 [originals-dir] [archive-dir]" >&2
@@ -15,6 +15,7 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 originals_dir="${1:-$repo_root/data/originals}"
 archive_dir="${2:-$repo_root/data/artifacts}"
 parser="$repo_root/check_register_parser.py"
+fund_update_parser="$repo_root/fund_update_parser.py"
 py_version="$(cat "$repo_root/.python-version")"
 
 prepare_dirs() {
@@ -22,7 +23,8 @@ prepare_dirs() {
   csv_dir="$archive_dir/csv"
   chunk_dir="$archive_dir/chunks"
   html_dir="$archive_dir/html"
-  mkdir -p "$pdf_dir" "$csv_dir" "$chunk_dir" "$html_dir"
+  fund_update_dir="$archive_dir/fund_updates"
+  mkdir -p "$pdf_dir" "$csv_dir" "$chunk_dir" "$html_dir" "$fund_update_dir"
 }
 
 run_parser() {
@@ -41,6 +43,47 @@ move_artifacts() {
   mv "$tmpdir/${prefix}.csv" "$csv_dir/"
   mv "$tmpdir/${prefix}-chunks.json" "$chunk_dir/"
   mv "$tmpdir/${prefix}-payees.html" "$html_dir/"
+}
+
+extract_fund_update() {
+  local packet_pdf="$1"
+  local tmpdir="$2"
+
+  local output
+  if output=$(PYENV_VERSION="$py_version" "$fund_update_parser" "$packet_pdf" --artifact-dir "$tmpdir" 2>&1); then
+    local -a fund_pdfs=()
+    while IFS= read -r -d '' file; do
+      fund_pdfs+=("$file")
+    done < <(find "$tmpdir" -maxdepth 1 -type f -name '*.pdf' -print0)
+
+    if [[ ${#fund_pdfs[@]} -eq 0 ]]; then
+      printf 'Fund update extraction succeeded but no PDF found for %s\n' "$(basename "$packet_pdf")" >&2
+      return 1
+    fi
+
+    local source_path="${fund_pdfs[0]}"
+    local filename="$(basename "$source_path")"
+    local destination="$fund_update_dir/$filename"
+    mv "$source_path" "$destination"
+
+    local pages=""
+    if [[ "$output" =~ \(pages[[:space:]](.+)\) ]]; then
+      pages="${BASH_REMATCH[1]}"
+    fi
+    if [[ -n "$pages" ]]; then
+      printf 'Fund update archived: %s (pages %s)\n' "$destination" "$pages"
+    else
+      printf 'Fund update archived: %s\n' "$destination"
+    fi
+  else
+    local status=$?
+    if [[ "$output" == *"No General Fund Budget Update pages found"* ]]; then
+      printf 'Fund update not found; skipping %s\n' "$(basename "$packet_pdf")"
+      return 0
+    fi
+    printf '%s\n' "$output" >&2
+    return "$status"
+  fi
 }
 
 process_packet() {
@@ -62,6 +105,8 @@ process_packet() {
   else
     echo "No register found; skipping"
   fi
+
+  extract_fund_update "$packet_pdf" "$tmpdir"
 
   rm -rf "$tmpdir"
   local elapsed=$(( $(date +%s) - start ))


### PR DESCRIPTION
## Summary
- update `build_register_archive.sh` to invoke the fund update extractor for each agenda packet
- ensure fund update artifacts land in `data/artifacts/fund_updates/` and log skip cases gracefully

Suggested squash commit message: Extract fund updates when rebuilding artifacts

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68c884f385348322ae2d61b1bf3d26be