### PR TITLE
Handle fund update default filename when rev lacks period

### DIFF
--- a/fund_update/page_extractor.py
+++ b/fund_update/page_extractor.py
@@ -11,7 +11,7 @@ _PAGE_COUNT_PATTERN = re.compile(
     r"Page\s+(?P<current>\d{1,2})\s+of\s+(?P<total>\d{1,2})", re.IGNORECASE
 )
 _DATE_PATTERN = re.compile(
-    r"\((?:rev\.\s*)?(?P<month>\d{1,2})\.(?P<day>\d{1,2})\.(?P<year>\d{4})\)",
+    r"\((?:rev\.?\s*)?(?P<month>\d{1,2})\.(?P<day>\d{1,2})\.(?P<year>\d{4})\)",
     re.IGNORECASE,
 )
 

--- a/tests/test_fund_update_extractor.py
+++ b/tests/test_fund_update_extractor.py
@@ -123,6 +123,12 @@ class TestFundUpdateExtractor(unittest.TestCase):
             default_fund_update_pdf_name(pdf_path),
             Path("2025-09-25-general-fund-update.pdf"),
         )
+
+        pdf_path_without_period = Path("Agenda Packet (rev 9.25.2025).pdf")
+        self.assertEqual(
+            default_fund_update_pdf_name(pdf_path_without_period),
+            Path("2025-09-25-general-fund-update.pdf"),
+        )
         self.assertIsNone(default_fund_update_pdf_name(Path("packet.pdf")))
 
     def test_cli_default_directory(self):


### PR DESCRIPTION
## Summary
- allow fund update filename derivation to accept agenda packets labelled "rev" without a trailing period
- add regression coverage for the "rev" without period filename pattern
Suggested squash commit message: Allow fund update parser to derive default name when 'rev' lacks a period

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68c888ad5284832284a211bf1ac60201