### PR TITLE
Handle amounts without dollar signs in check register parsing

### DIFF
--- a/check_register/parser.py
+++ b/check_register/parser.py
@@ -53,8 +53,8 @@ class CheckRegisterParser:
     # Lines containing a VOID marker anywhere
     _void_marker = re.compile(r"\bVOID(?:ED|ED/REISSUED)?\b", re.IGNORECASE)
 
-    # Amount is last token (with optional minus) like $12,345.67
-    _amount_tail = re.compile(r"\$-?\d[\d,]*(?:\.\d{2}|\d{2})$")
+    # Amount is last token (with optional minus) like $12,345.67 or 12,345.67
+    _amount_tail = re.compile(r"\$?-?\d[\d,]*(?:\.\d{2}|\d{2})$")
 
     # Obvious non-data lines to skip
     _skip_line = re.compile(
@@ -291,6 +291,5 @@ class CheckRegisterParser:
     def extract(self) -> List[CheckEntry]:
         chunks = self.extract_raw_chunks()
         return self.parse_chunks(chunks)
-
 
 

--- a/tests/test_parse_chunk_cases.py
+++ b/tests/test_parse_chunk_cases.py
@@ -40,6 +40,33 @@ class TestParseChunkCases(unittest.TestCase):
         self.assertIn('Missing amount in row', logs.output[0])
         self.assertEqual(entry.amount, Decimal('0'))
 
+    def test_amount_without_dollar_sign_parses(self):
+        parser = CheckRegisterParser(Path('dummy'))
+        line_words = [
+            [
+                PositionedWord(text='1000', x0=7.8),
+                PositionedWord(text='06/01/2025', x0=52.0),
+                PositionedWord(text='Open', x0=85.0),
+                PositionedWord(text='Accounts', x0=214.2),
+                PositionedWord(text='Payable', x0=238.2),
+                PositionedWord(text='CITY', x0=287.6),
+                PositionedWord(text='OF', x0=300.0),
+                PositionedWord(text='RICHMOND', x0=314.0),
+                PositionedWord(text='Fire', x0=444.2),
+                PositionedWord(text='services', x0=460.3),
+                PositionedWord(text='1,234.56', x0=540.0),
+            ]
+        ]
+        chunk = RowChunk(
+            section_month=6,
+            section_year=2025,
+            ap_type='check',
+            lines=['1000 06/01/2025 Open Accounts Payable CITY OF RICHMOND Fire services 1,234.56'],
+            line_words=line_words,
+        )
+        entry = parser.parse_chunks([chunk])[0]
+        self.assertEqual(entry.amount, Decimal('1234.56'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Motivation
- Some PDF-extracted rows include trailing amounts without a leading `$`, causing the parser to miss the amount and log spurious "Missing amount" warnings.

### Description
- Allow the trailing-amount matcher to optionally omit the dollar sign by changing `_amount_tail` to accept `12,345.67` as well as `$12,345.67`, and add a regression test for the case.

### Testing
- Ran `python -m unittest discover -s tests` and all tests (54) passed, and a new test `test_amount_without_dollar_sign_parses` in `tests/test_parse_chunk_cases.py` verifies parsing of amounts without `$`; Suggested commit message: `Handle amounts without dollar signs`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697005c13adc83229d8d9724c988b878)